### PR TITLE
feat: Create directly without schema predefined

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,193 @@
 
 # GreptimeDB Go Ingester
 
-NOTE: the project is still in its early stages.
+Provide API to insert data into GreptimeDB.
 
-Provide API for using GreptimeDB ingester in Go.
+## How To Use
 
-## Installation
+### Installation
 
 ```sh
 go get -u github.com/GreptimeTeam/greptimedb-ingester-go
 ```
 
-## Documentation
+### Example
 
-TODO
+#### Config
+
+Initiate a Config for Client or StreamClient
+
+```go
+cfg := config.New("<host>").
+    WithAuth("<username>", "<password>").
+    WithDatabase(database)
+```
+
+##### Options
+
+- keepalive
+
+```go
+cfg = cfg.WithKeepalive(30*time.Second, 5*time.Second)
+```
+
+#### Client or StreamClient
+
+- Client
+
+```go
+cli, err := client.New(cfg)
+```
+
+- StreamClient
+
+```go
+
+stream, err := client.NewStreamClient(cfg)
+```
+
+#### Insert & StreamInsert
+
+streaming insert is to Send data into GreptimeDB without waiting for response.
+
+##### Datatypes supported
+
+###### Go
+
+- int, int8, int16, int32, int64
+- uint, uint8, uint16, uint32, uint64
+- float32, float64
+- bool
+- string
+- []byte, []uint8, [N]byte, [N]uint8
+- time.Time
+
+###### GreptimeDB
+
+- INT, INT8, INT16, INT32, INT64
+- UINT, UINT8, UINT16, UINT32, UINT64
+- FLOAT, FLOAT32, FLOAT64
+- BOOL, BOOLEAN
+- STRING
+- BINARY, BYTES
+- DATE     // the day elapsed since January 1, 1970.
+- DATETIME // the milliseconds elapsed since January 1, 1970.
+- TIMESTAMP
+- TIMESTAMP_SECOND
+- TIMESTAMP_MILLISECOND
+- TIMESTAMP_MICROSECOND
+- TIMESTAMP_NANOSECOND
+
+NOTE: the following are the same
+
+- INT, INT64
+- UINT, UINT64
+- FLOAT, FLOAT64
+- BOOL, BOOLEAN
+- BINARY, BYTES
+- TIMESTAMP, TIMESTAMP_MILLISECOND
+
+##### With Schema predefined explicitly
+
+###### define table schema, and add rows
+
+```go
+tbl, err := table.New("<table_name>")
+
+tbl.AddTagColumn("id", types.INT64)
+tbl.AddFieldColumn("host", types.STRING)
+tbl.AddTimestampColumn("ts", types.TIMESTAMP_MILLISECOND)
+
+err := tbl.AddRow(1, "127.0.0.1", time.Now())
+err := tbl.AddRow(2, "127.0.0.2", time.Now())
+...
+```
+
+###### Client Write into GreptimeDB
+
+```go
+resp, err := cli.Write(context.Background(), tbl)
+```
+
+###### StreamClient Send into GreptimeDB
+
+```go
+err := streamClient.Send(context.Background(), tbl)
+```
+
+##### With Schema defined in struct Tag
+
+###### Tag
+
+- `greptime` is the tag key
+- `tag`, `field`, `timestamp` is for [SemanticType][data-model]
+- `column` is to define the column name
+- `type` is to define the data type. if type is timestamp, `precision` is supported
+
+type supported is the same as described [Datatypes supported in GreptimeDB](#greptimedb), and case insensitive.
+
+###### define struct with tags
+
+```go
+type Monitor struct {
+    ID          int64     `greptime:"tag;column:id;type:int64"`
+    Host        string    `greptime:"field;column:host;type:string"`
+    Ts          time.Time `greptime:"timestamp;column:ts;type:timestamp;precision:millisecond"`
+}
+
+// TableName is to define the table name.
+// if TableName method is not found, the snake style and lower case of struct name
+// will be used as table name. The table name is `monitor` if TableName method not found.
+func (Monitor) TableName() string {
+    return "<table_name>"
+}
+```
+
+###### instance your struct
+
+```go
+monitors := []Monitor{
+    {
+        ID:          randomId(),
+        Host:        "127.0.0.1",
+        Running:     true,
+    },
+    {
+        ID:          randomId(),
+        Host:        "127.0.0.2",
+        Running:     true,
+    },
+}
+```
+
+###### Client Create into GreptimeDB
+
+```go
+resp, err := cli.Create(context.Background(), monitors)
+```
+
+###### StreamClient Create into GreptimeDB
+
+```go
+err := streamClient.Create(context.Background(), monitors)
+```
+
+#### Query
+
+You can use ORM library like [gorm][gorm] with MySQL or PostgreSQL driver to [connect][connect] GreptimeDB and retrieve data from it.
+
+```go
+type Monitor struct {
+    ID          int64     `gorm:"primaryKey;column:id"`
+    Host        string    `gorm:"column:host"`
+    Ts          time.Time `gorm:"column:ts"`
+}
+
+// Get all monitors
+var monitors []Monitor
+result := db.Find(&monitors)
+```
+
+[gorm]: https://gorm.io/
+[connect]: https://gorm.io/docs/connecting_to_the_database.html
+[data-model]: https://docs.greptime.com/user-guide/concepts/data-model

--- a/README.md
+++ b/README.md
@@ -6,6 +6,22 @@
 
 Provide API to insert data into GreptimeDB.
 
+start GreptimeDB via Docker
+
+```shell
+docker run --rm -p 4000-4003:4000-4003 \
+--name greptime greptime/greptimedb standalone start \
+--http-addr 0.0.0.0:4000 \
+--rpc-addr 0.0.0.0:4001 \
+--mysql-addr 0.0.0.0:4002 \
+--postgres-addr 0.0.0.0:4003
+```
+
+## Basic Example
+
+- [schema](examples/schema/main.go)
+- [tag](examples/tag/main.go)
+
 ## How To Use
 
 ### Installation

--- a/client/client.go
+++ b/client/client.go
@@ -70,6 +70,44 @@ func (c *Client) Write(ctx context.Context, tables ...*table.Table) (*gpb.Grepti
 	return c.client.Handle(ctx, request_)
 }
 
+// Create is like [Write] to write the data into GreptimeDB, but schema is defined in the struct tag.
+//
+//		type monitor struct {
+//		  ID          int64     `greptime:"tag;column:id;type:int64"`
+//		  Host        string    `greptime:"tag;column:host;type:string"`
+//		  Memory      uint64    `greptime:"field;column:memory;type:uint64"`
+//		  Cpu         float64   `greptime:"field;column:cpu;type:float64"`
+//		  Temperature int64     `greptime:"field;column:temperature;type:int64"`
+//		  Running     bool      `greptime:"field;column:running;type:boolean"`
+//		  Ts          time.Time `greptime:"timestamp;column:ts;type:timestamp;precision:millisecond"`
+//		}
+//
+//		func (monitor) TableName() string {
+//		  return monitorTableName
+//		}
+//
+//		monitors := []monitor{
+//			{
+//			    ID:          randomId(),
+//			    Host:        "127.0.0.1",
+//			    Memory:      1,
+//			    Cpu:         1.0,
+//			    Temperature: -1,
+//			    Ts:          time1,
+//			    Running:     true,
+//			},
+//			{
+//			    ID:          randomId(),
+//			    Host:        "127.0.0.2",
+//			    Memory:      2,
+//			    Cpu:         2.0,
+//			    Temperature: -2,
+//			    Ts:          time2,
+//			    Running:     true,
+//			},
+//	  }
+//
+//		resp, err := client.Create(context.Background(), monitors)
 func (c *Client) Create(ctx context.Context, body any) (*gpb.GreptimeResponse, error) {
 	tbl, err := schema.Parse(body)
 	if err != nil {

--- a/client/client.go
+++ b/client/client.go
@@ -48,19 +48,19 @@ func New(cfg *config.Config) (*Client, error) {
 
 // Write is to write the data into GreptimeDB via explicit schema.
 //
-//	    tbl := table.New(<tableName>)
+//	tbl := table.New(<tableName>)
 //
-//		// add column at first. This is to define the schema of the table.
-//		tbl.AddTagColumn("tag1", types.INT64)
-//		tbl.AddFieldColumn("field1", types.STRING)
-//		tbl.AddFieldColumn("field2", types.DOUBLE)
-//		tbl.AddTimestampColumn("timestamp", types.TIMESTAMP_MILLISECONDS)
+//	// add column at first. This is to define the schema of the table.
+//	tbl.AddTagColumn("tag1", types.INT64)
+//	tbl.AddFieldColumn("field1", types.STRING)
+//	tbl.AddFieldColumn("field2", types.DOUBLE)
+//	tbl.AddTimestampColumn("timestamp", types.TIMESTAMP_MILLISECONDS)
 //
-//		// you can add multiple row(s). This is the real data.
-//		tbl.AddRow(1, "hello", 1.1, time.Now())
+//	// you can add multiple row(s). This is the real data.
+//	tbl.AddRow(1, "hello", 1.1, time.Now())
 //
-//		// write data into GreptimeDB
-//		resp, err := client.Write(context.Background(), tbl)
+//	// write data into GreptimeDB
+//	resp, err := client.Write(context.Background(), tbl)
 func (c *Client) Write(ctx context.Context, tables ...*table.Table) (*gpb.GreptimeResponse, error) {
 	header_ := header.New(c.cfg.Database).WithAuth(c.cfg.Username, c.cfg.Password)
 	request_, err := request.New(header_, tables...).Build()
@@ -72,42 +72,42 @@ func (c *Client) Write(ctx context.Context, tables ...*table.Table) (*gpb.Grepti
 
 // Create is like [Write] to write the data into GreptimeDB, but schema is defined in the struct tag.
 //
-//		type monitor struct {
-//		  ID          int64     `greptime:"tag;column:id;type:int64"`
-//		  Host        string    `greptime:"tag;column:host;type:string"`
-//		  Memory      uint64    `greptime:"field;column:memory;type:uint64"`
-//		  Cpu         float64   `greptime:"field;column:cpu;type:float64"`
-//		  Temperature int64     `greptime:"field;column:temperature;type:int64"`
-//		  Running     bool      `greptime:"field;column:running;type:boolean"`
-//		  Ts          time.Time `greptime:"timestamp;column:ts;type:timestamp;precision:millisecond"`
-//		}
+//	type monitor struct {
+//	  ID          int64     `greptime:"tag;column:id;type:int64"`
+//	  Host        string    `greptime:"tag;column:host;type:string"`
+//	  Memory      uint64    `greptime:"field;column:memory;type:uint64"`
+//	  Cpu         float64   `greptime:"field;column:cpu;type:float64"`
+//	  Temperature int64     `greptime:"field;column:temperature;type:int64"`
+//	  Running     bool      `greptime:"field;column:running;type:boolean"`
+//	  Ts          time.Time `greptime:"timestamp;column:ts;type:timestamp;precision:millisecond"`
+//	}
 //
-//		func (monitor) TableName() string {
-//		  return monitorTableName
-//		}
+//	func (monitor) TableName() string {
+//	  return monitorTableName
+//	}
 //
-//		monitors := []monitor{
-//			{
-//			    ID:          randomId(),
-//			    Host:        "127.0.0.1",
-//			    Memory:      1,
-//			    Cpu:         1.0,
-//			    Temperature: -1,
-//			    Ts:          time1,
-//			    Running:     true,
-//			},
-//			{
-//			    ID:          randomId(),
-//			    Host:        "127.0.0.2",
-//			    Memory:      2,
-//			    Cpu:         2.0,
-//			    Temperature: -2,
-//			    Ts:          time2,
-//			    Running:     true,
-//			},
-//	  }
+//	monitors := []monitor{
+//		{
+//		    ID:          randomId(),
+//		    Host:        "127.0.0.1",
+//		    Memory:      1,
+//		    Cpu:         1.0,
+//		    Temperature: -1,
+//		    Ts:          time1,
+//		    Running:     true,
+//		},
+//		{
+//		    ID:          randomId(),
+//		    Host:        "127.0.0.2",
+//		    Memory:      2,
+//		    Cpu:         2.0,
+//		    Temperature: -2,
+//		    Ts:          time2,
+//		    Running:     true,
+//		},
+//	}
 //
-//		resp, err := client.Create(context.Background(), monitors)
+//	resp, err := client.Create(context.Background(), monitors)
 func (c *Client) Create(ctx context.Context, body any) (*gpb.GreptimeResponse, error) {
 	tbl, err := schema.Parse(body)
 	if err != nil {

--- a/client/client.go
+++ b/client/client.go
@@ -48,13 +48,13 @@ func New(cfg *config.Config) (*Client, error) {
 
 // Write is to write the data into GreptimeDB via explicit schema.
 //
-//	tbl := table.New(<tableName>)
+//	tbl, err := table.New(<tableName>)
 //
 //	// add column at first. This is to define the schema of the table.
 //	tbl.AddTagColumn("tag1", types.INT64)
 //	tbl.AddFieldColumn("field1", types.STRING)
-//	tbl.AddFieldColumn("field2", types.DOUBLE)
-//	tbl.AddTimestampColumn("timestamp", types.TIMESTAMP_MILLISECONDS)
+//	tbl.AddFieldColumn("field2", types.FLOAT64)
+//	tbl.AddTimestampColumn("timestamp", types.TIMESTAMP_MILLISECOND)
 //
 //	// you can add multiple row(s). This is the real data.
 //	tbl.AddRow(1, "hello", 1.1, time.Now())
@@ -72,7 +72,7 @@ func (c *Client) Write(ctx context.Context, tables ...*table.Table) (*gpb.Grepti
 
 // Create is like [Write] to write the data into GreptimeDB, but schema is defined in the struct tag.
 //
-//	type monitor struct {
+//	type Monitor struct {
 //	  ID          int64     `greptime:"tag;column:id;type:int64"`
 //	  Host        string    `greptime:"tag;column:host;type:string"`
 //	  Memory      uint64    `greptime:"field;column:memory;type:uint64"`
@@ -82,11 +82,11 @@ func (c *Client) Write(ctx context.Context, tables ...*table.Table) (*gpb.Grepti
 //	  Ts          time.Time `greptime:"timestamp;column:ts;type:timestamp;precision:millisecond"`
 //	}
 //
-//	func (monitor) TableName() string {
+//	func (Monitor) TableName() string {
 //	  return monitorTableName
 //	}
 //
-//	monitors := []monitor{
+//	monitors := []Monitor{
 //		{
 //		    ID:          randomId(),
 //		    Host:        "127.0.0.1",

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -92,13 +92,13 @@ func (datatype) TableName() string {
 }
 
 type monitor struct {
-	ID          int64     `gorm:"primaryKey;column:id"   greptime:"tag;column:id;type=int64"`
-	Host        string    `gorm:"primaryKey;column:host" greptime:"tag;column=host;type=string"`
-	Memory      uint64    `gorm:"column:memory"          greptime:"field;column=memory;type=uint64"`
-	Cpu         float64   `gorm:"column:cpu"             greptime:"field;column=cpu;type=float64"`
-	Temperature int64     `gorm:"column:temperature"     greptime:"field;column=temperature;type=int64"`
-	Running     bool      `gorm:"column:running"         greptime:"field;column=running;type=boolean"`
-	Ts          time.Time `gorm:"column:ts"              greptime:"timestamp;column=ts;type=timestamp;precision=millisecond"`
+	ID          int64     `gorm:"primaryKey;column:id"   greptime:"tag;column:id;type:int64"`
+	Host        string    `gorm:"primaryKey;column:host" greptime:"tag;column:host;type:string"`
+	Memory      uint64    `gorm:"column:memory"          greptime:"field;column:memory;type:uint64"`
+	Cpu         float64   `gorm:"column:cpu"             greptime:"field;column:cpu;type:float64"`
+	Temperature int64     `gorm:"column:temperature"     greptime:"field;column:temperature;type:int64"`
+	Running     bool      `gorm:"column:running"         greptime:"field;column:running;type:boolean"`
+	Ts          time.Time `gorm:"column:ts"              greptime:"timestamp;column:ts;type:timestamp;precision:millisecond"`
 }
 
 func (monitor) TableName() string {
@@ -244,7 +244,6 @@ func init() {
 
 	cli = newClient()
 	db = newMysql()
-	streamClient = newStreamClient()
 }
 
 func TestWriteMonitors(t *testing.T) {

--- a/client/stream_client.go
+++ b/client/stream_client.go
@@ -50,13 +50,13 @@ func NewStreamClient(cfg *config.Config) (*StreamClient, error) {
 
 // Send is to send the data into GreptimeDB via explicit schema.
 //
-//	tbl := table.New(<tableName>)
+//	tbl, err := table.New(<tableName>)
 //
 //	// add column at first. This is to define the schema of the table.
 //	tbl.AddTagColumn("tag1", types.INT64)
 //	tbl.AddFieldColumn("field1", types.STRING)
-//	tbl.AddFieldColumn("field2", types.DOUBLE)
-//	tbl.AddTimestampColumn("timestamp", types.TIMESTAMP_MILLISECONDS)
+//	tbl.AddFieldColumn("field2", types.FLOAT64)
+//	tbl.AddTimestampColumn("timestamp", types.TIMESTAMP_MILLISECOND)
 //
 //	// you can add multiple row(s). This is the real data.
 //	tbl.AddRow(1, "hello", 1.1, time.Now())

--- a/client/stream_client.go
+++ b/client/stream_client.go
@@ -50,19 +50,19 @@ func NewStreamClient(cfg *config.Config) (*StreamClient, error) {
 
 // Send is to send the data into GreptimeDB via explicit schema.
 //
-//	    tbl := table.New(<tableName>)
+//	tbl := table.New(<tableName>)
 //
-//		// add column at first. This is to define the schema of the table.
-//		tbl.AddTagColumn("tag1", types.INT64)
-//		tbl.AddFieldColumn("field1", types.STRING)
-//		tbl.AddFieldColumn("field2", types.DOUBLE)
-//		tbl.AddTimestampColumn("timestamp", types.TIMESTAMP_MILLISECONDS)
+//	// add column at first. This is to define the schema of the table.
+//	tbl.AddTagColumn("tag1", types.INT64)
+//	tbl.AddFieldColumn("field1", types.STRING)
+//	tbl.AddFieldColumn("field2", types.DOUBLE)
+//	tbl.AddTimestampColumn("timestamp", types.TIMESTAMP_MILLISECONDS)
 //
-//		// you can add multiple row(s). This is the real data.
-//		tbl.AddRow(1, "hello", 1.1, time.Now())
+//	// you can add multiple row(s). This is the real data.
+//	tbl.AddRow(1, "hello", 1.1, time.Now())
 //
-//		// send data into GreptimeDB
-//		resp, err := streamClient.Send(context.Background(), tbl)
+//	// send data into GreptimeDB
+//	resp, err := streamClient.Send(context.Background(), tbl)
 func (c *StreamClient) Send(ctx context.Context, tables ...*table.Table) error {
 	header_ := header.New(c.cfg.Database).WithAuth(c.cfg.Username, c.cfg.Password)
 	request_, err := request.New(header_, tables...).Build()
@@ -74,42 +74,42 @@ func (c *StreamClient) Send(ctx context.Context, tables ...*table.Table) error {
 
 // Create is like [Send] to send the data into GreptimeDB, but schema is defined in the struct tag.
 //
-//		type monitor struct {
-//		  ID          int64     `greptime:"tag;column:id;type:int64"`
-//		  Host        string    `greptime:"tag;column:host;type:string"`
-//		  Memory      uint64    `greptime:"field;column:memory;type:uint64"`
-//		  Cpu         float64   `greptime:"field;column:cpu;type:float64"`
-//		  Temperature int64     `greptime:"field;column:temperature;type:int64"`
-//		  Running     bool      `greptime:"field;column:running;type:boolean"`
-//		  Ts          time.Time `greptime:"timestamp;column:ts;type:timestamp;precision:millisecond"`
-//		}
+//	type monitor struct {
+//	  ID          int64     `greptime:"tag;column:id;type:int64"`
+//	  Host        string    `greptime:"tag;column:host;type:string"`
+//	  Memory      uint64    `greptime:"field;column:memory;type:uint64"`
+//	  Cpu         float64   `greptime:"field;column:cpu;type:float64"`
+//	  Temperature int64     `greptime:"field;column:temperature;type:int64"`
+//	  Running     bool      `greptime:"field;column:running;type:boolean"`
+//	  Ts          time.Time `greptime:"timestamp;column:ts;type:timestamp;precision:millisecond"`
+//	}
 //
-//		func (monitor) TableName() string {
-//		  return monitorTableName
-//		}
+//	func (monitor) TableName() string {
+//	  return monitorTableName
+//	}
 //
-//		monitors := []monitor{
-//			{
-//			    ID:          randomId(),
-//			    Host:        "127.0.0.1",
-//			    Memory:      1,
-//			    Cpu:         1.0,
-//			    Temperature: -1,
-//			    Ts:          time1,
-//			    Running:     true,
-//			},
-//			{
-//			    ID:          randomId(),
-//			    Host:        "127.0.0.2",
-//			    Memory:      2,
-//			    Cpu:         2.0,
-//			    Temperature: -2,
-//			    Ts:          time2,
-//			    Running:     true,
-//			},
-//	  }
+//	monitors := []monitor{
+//		{
+//		    ID:          randomId(),
+//		    Host:        "127.0.0.1",
+//		    Memory:      1,
+//		    Cpu:         1.0,
+//		    Temperature: -1,
+//		    Ts:          time1,
+//		    Running:     true,
+//		},
+//		{
+//		    ID:          randomId(),
+//		    Host:        "127.0.0.2",
+//		    Memory:      2,
+//		    Cpu:         2.0,
+//		    Temperature: -2,
+//		    Ts:          time2,
+//		    Running:     true,
+//		},
+//	}
 //
-//		resp, err := streamClient.Create(context.Background(), monitors)
+//	resp, err := streamClient.Create(context.Background(), monitors)
 func (c *StreamClient) Create(ctx context.Context, body any) error {
 	tbl, err := schema.Parse(body)
 	if err != nil {

--- a/client/stream_client.go
+++ b/client/stream_client.go
@@ -48,6 +48,21 @@ func NewStreamClient(cfg *config.Config) (*StreamClient, error) {
 	return &StreamClient{client: client, cfg: cfg}, nil
 }
 
+// Send is to send the data into GreptimeDB via explicit schema.
+//
+//	    tbl := table.New(<tableName>)
+//
+//		// add column at first. This is to define the schema of the table.
+//		tbl.AddTagColumn("tag1", types.INT64)
+//		tbl.AddFieldColumn("field1", types.STRING)
+//		tbl.AddFieldColumn("field2", types.DOUBLE)
+//		tbl.AddTimestampColumn("timestamp", types.TIMESTAMP_MILLISECONDS)
+//
+//		// you can add multiple row(s). This is the real data.
+//		tbl.AddRow(1, "hello", 1.1, time.Now())
+//
+//		// send data into GreptimeDB
+//		resp, err := streamClient.Send(context.Background(), tbl)
 func (c *StreamClient) Send(ctx context.Context, tables ...*table.Table) error {
 	header_ := header.New(c.cfg.Database).WithAuth(c.cfg.Username, c.cfg.Password)
 	request_, err := request.New(header_, tables...).Build()
@@ -57,7 +72,45 @@ func (c *StreamClient) Send(ctx context.Context, tables ...*table.Table) error {
 	return c.client.Send(request_)
 }
 
-func (c *StreamClient) Write(ctx context.Context, body any) error {
+// Create is like [Send] to send the data into GreptimeDB, but schema is defined in the struct tag.
+//
+//		type monitor struct {
+//		  ID          int64     `greptime:"tag;column:id;type:int64"`
+//		  Host        string    `greptime:"tag;column:host;type:string"`
+//		  Memory      uint64    `greptime:"field;column:memory;type:uint64"`
+//		  Cpu         float64   `greptime:"field;column:cpu;type:float64"`
+//		  Temperature int64     `greptime:"field;column:temperature;type:int64"`
+//		  Running     bool      `greptime:"field;column:running;type:boolean"`
+//		  Ts          time.Time `greptime:"timestamp;column:ts;type:timestamp;precision:millisecond"`
+//		}
+//
+//		func (monitor) TableName() string {
+//		  return monitorTableName
+//		}
+//
+//		monitors := []monitor{
+//			{
+//			    ID:          randomId(),
+//			    Host:        "127.0.0.1",
+//			    Memory:      1,
+//			    Cpu:         1.0,
+//			    Temperature: -1,
+//			    Ts:          time1,
+//			    Running:     true,
+//			},
+//			{
+//			    ID:          randomId(),
+//			    Host:        "127.0.0.2",
+//			    Memory:      2,
+//			    Cpu:         2.0,
+//			    Temperature: -2,
+//			    Ts:          time2,
+//			    Running:     true,
+//			},
+//	  }
+//
+//		resp, err := streamClient.Create(context.Background(), monitors)
+func (c *StreamClient) Create(ctx context.Context, body any) error {
 	tbl, err := schema.Parse(body)
 	if err != nil {
 		return err

--- a/client/stream_client_test.go
+++ b/client/stream_client_test.go
@@ -28,10 +28,6 @@ import (
 	"github.com/GreptimeTeam/greptimedb-ingester-go/table/types"
 )
 
-var (
-	streamClient *StreamClient
-)
-
 func newStreamClient() *StreamClient {
 	cfg := config.New(host).
 		WithPort(grpcPort).
@@ -92,6 +88,7 @@ func TestStreamWrite(t *testing.T) {
 		assert.Nil(t, err)
 	}
 
+	streamClient := newStreamClient()
 	err = streamClient.Send(context.Background(), table)
 	assert.Nil(t, err)
 	affected, err := streamClient.CloseAndRecv(context.Background())
@@ -137,7 +134,8 @@ func TestStreamCreate(t *testing.T) {
 		},
 	}
 
-	err = streamClient.Write(context.Background(), monitors)
+	streamClient := newStreamClient()
+	err = streamClient.Create(context.Background(), monitors)
 	assert.Nil(t, err)
 	affected, err := streamClient.CloseAndRecv(context.Background())
 	assert.EqualValues(t, 2, affected.GetValue())

--- a/examples/schema/main.go
+++ b/examples/schema/main.go
@@ -1,0 +1,80 @@
+/*
+with schema predefined
+*/
+package main
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/GreptimeTeam/greptimedb-ingester-go/client"
+	"github.com/GreptimeTeam/greptimedb-ingester-go/config"
+	"github.com/GreptimeTeam/greptimedb-ingester-go/table"
+	"github.com/GreptimeTeam/greptimedb-ingester-go/table/types"
+)
+
+var (
+	cli    *client.Client
+	stream *client.StreamClient
+)
+
+func init() {
+	cfg := config.New("127.0.0.1").WithDatabase("public")
+
+	cli_, err := client.New(cfg)
+	if err != nil {
+		log.Fatal(err)
+	}
+	cli = cli_
+
+	stream_, err := client.NewStreamClient(cfg)
+	if err != nil {
+		log.Fatal(err)
+	}
+	stream = stream_
+}
+
+func main() {
+	tbl, err := table.New("monitors_with_schema")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// add column at first. This is to define the schema of the table.
+	if err := tbl.AddTagColumn("id", types.INT64); err != nil {
+		log.Fatal(err)
+	}
+	if err := tbl.AddFieldColumn("host", types.STRING); err != nil {
+		log.Fatal(err)
+	}
+	if err := tbl.AddFieldColumn("temperature", types.FLOAT); err != nil {
+		log.Fatal(err)
+	}
+	if err := tbl.AddTimestampColumn("timestamp", types.TIMESTAMP_MICROSECOND); err != nil {
+		log.Fatal(err)
+	}
+
+	if err := tbl.AddRow(1, "hello", 1.1, time.Now()); err != nil {
+		log.Fatal(err)
+	}
+	if err := tbl.AddRow(2, "hello", 2.2, time.Now()); err != nil {
+		log.Fatal(err)
+	}
+
+	{ // client write data into GreptimeDB
+		resp, err := cli.Write(context.Background(), tbl)
+		if err != nil {
+			log.Fatal(err)
+		}
+		log.Printf("affected rows: %d\n", resp.GetAffectedRows().GetValue())
+	}
+
+	{ // stream client send data into GreptimeDB
+		err := stream.Send(context.Background(), tbl)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+
+}

--- a/examples/schema/main.go
+++ b/examples/schema/main.go
@@ -1,6 +1,17 @@
-/*
-with schema predefined
-*/
+// Copyright 2024 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/examples/tag/main.go
+++ b/examples/tag/main.go
@@ -1,6 +1,17 @@
-/*
-with schema undefined
-*/
+// Copyright 2024 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/examples/tag/main.go
+++ b/examples/tag/main.go
@@ -1,0 +1,87 @@
+/*
+with schema undefined
+*/
+package main
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/GreptimeTeam/greptimedb-ingester-go/client"
+	"github.com/GreptimeTeam/greptimedb-ingester-go/config"
+)
+
+var (
+	cli    *client.Client
+	stream *client.StreamClient
+)
+
+func init() {
+	cfg := config.New("127.0.0.1").WithDatabase("public")
+
+	cli_, err := client.New(cfg)
+	if err != nil {
+		log.Fatal(err)
+	}
+	cli = cli_
+
+	stream_, err := client.NewStreamClient(cfg)
+	if err != nil {
+		log.Fatal(err)
+	}
+	stream = stream_
+}
+
+type Monitor struct {
+	ID          int64     `greptime:"tag;column:id;type:int64"`
+	Host        string    `greptime:"tag;column:host;type:string"`
+	Memory      uint64    `greptime:"field;column:memory;type:uint64"`
+	Cpu         float64   `greptime:"field;column:cpu;type:float64"`
+	Temperature int64     `greptime:"field;column:temperature;type:int64"`
+	Running     bool      `greptime:"field;column:running;type:boolean"`
+	Ts          time.Time `greptime:"timestamp;column:ts;type:timestamp;precision:millisecond"`
+}
+
+func (Monitor) TableName() string {
+	return "monitors_with_tag"
+}
+
+func main() {
+
+	monitors := []Monitor{
+		{
+			ID:          1,
+			Host:        "127.0.0.1",
+			Memory:      1,
+			Cpu:         1.0,
+			Temperature: -1,
+			Ts:          time.Now(),
+			Running:     true,
+		},
+		{
+			ID:          2,
+			Host:        "127.0.0.2",
+			Memory:      2,
+			Cpu:         2.0,
+			Temperature: -2,
+			Ts:          time.Now(),
+			Running:     true,
+		},
+	}
+
+	{ // client write data into GreptimeDB
+		_, err := cli.Create(context.Background(), monitors)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	{ // stream client send data into GreptimeDB
+		err := stream.Create(context.Background(), monitors)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+
+}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -51,6 +51,10 @@ func getTableName(typ reflect.Type) (string, error) {
 }
 
 func Parse(input any) (*table.Table, error) {
+	if input == nil {
+		return nil, fmt.Errorf("unsupported empty data. %#v", input)
+	}
+
 	schema_, err := parseSchema(input)
 	if err != nil {
 		return nil, err
@@ -89,10 +93,6 @@ func indirectStruct(input any) (reflect.Type, error) {
 }
 
 func parseSchema(input any) (*Schema, error) {
-	if input == nil {
-		return nil, fmt.Errorf("unsupported data type: %+v", input)
-	}
-
 	typ, err := indirectStruct(input)
 	if err != nil {
 		return nil, err

--- a/table/table.go
+++ b/table/table.go
@@ -66,6 +66,10 @@ func (t *Table) addColumn(name string, semanticType gpb.SemanticType, dataType g
 	return nil
 }
 
+// AddTagColumn helps to add the tag column. You can find details in
+// [Data Model].
+//
+// [Data Model]: https://docs.greptime.com/user-guide/concepts/data-model
 func (t *Table) AddTagColumn(name string, type_ types.ColumnType) error {
 	typ, err := types.ConvertType(type_)
 	if err != nil {
@@ -75,6 +79,10 @@ func (t *Table) AddTagColumn(name string, type_ types.ColumnType) error {
 	return t.addColumn(name, gpb.SemanticType_TAG, typ)
 }
 
+// AddFieldColumn helps to add the field column. You can find details in
+// [Data Model].
+//
+// [Data Model]: https://docs.greptime.com/user-guide/concepts/data-model
 func (t *Table) AddFieldColumn(name string, type_ types.ColumnType) error {
 	typ, err := types.ConvertType(type_)
 	if err != nil {
@@ -84,7 +92,10 @@ func (t *Table) AddFieldColumn(name string, type_ types.ColumnType) error {
 	return t.addColumn(name, gpb.SemanticType_FIELD, typ)
 }
 
-// AddTimestampColumn helps to add the time index column
+// AddTimestampColumn helps to add the timestamp column. A table can only
+// have one timestamp column. You can find details in [Data Model].
+//
+// [Data Model]: https://docs.greptime.com/user-guide/concepts/data-model
 func (t *Table) AddTimestampColumn(name string, type_ types.ColumnType) error {
 	typ, err := types.ConvertType(type_)
 	if err != nil {
@@ -107,7 +118,21 @@ func (t *Table) addRow(row *gpb.Row) error {
 	return nil
 }
 
-// AddRow will check if the input matches the schema
+// AddRow is to add real data based on the schema defined before by
+// AddTagColumn(), AddFieldColumn() or AddTimestampColumn().
+//
+// NOTE: The order of inputs MUST match the order of columns in the schema.
+//
+//		tbl := table.New(<tableName>)
+//
+//		// add column at first. This is to define the schema of the table.
+//		tbl.AddTagColumn("tag1", types.INT64)
+//		tbl.AddFieldColumn("field1", types.STRING)
+//		tbl.AddTimestampColumn("timestamp", types.TIMESTAMP_MILLISECONDS)
+//
+//		// you can add multiple row(s). This is the real data.
+//		tbl.AddRow(1, "hello", time.Now())
+//	    tbl.AddRow(2, "world", time.Now())
 func (t *Table) AddRow(inputs ...any) error {
 	if t.IsColumnEmpty() {
 		return errs.ErrEmptyColumn

--- a/table/table.go
+++ b/table/table.go
@@ -123,16 +123,16 @@ func (t *Table) addRow(row *gpb.Row) error {
 //
 // NOTE: The order of inputs MUST match the order of columns in the schema.
 //
-//		tbl := table.New(<tableName>)
+//	tbl := table.New(<tableName>)
 //
-//		// add column at first. This is to define the schema of the table.
-//		tbl.AddTagColumn("tag1", types.INT64)
-//		tbl.AddFieldColumn("field1", types.STRING)
-//		tbl.AddTimestampColumn("timestamp", types.TIMESTAMP_MILLISECONDS)
+//	// add column at first. This is to define the schema of the table.
+//	tbl.AddTagColumn("tag1", types.INT64)
+//	tbl.AddFieldColumn("field1", types.STRING)
+//	tbl.AddTimestampColumn("timestamp", types.TIMESTAMP_MILLISECONDS)
 //
-//		// you can add multiple row(s). This is the real data.
-//		tbl.AddRow(1, "hello", time.Now())
-//	    tbl.AddRow(2, "world", time.Now())
+//	// you can add multiple row(s). This is the real data.
+//	tbl.AddRow(1, "hello", time.Now())
+//	tbl.AddRow(2, "world", time.Now())
 func (t *Table) AddRow(inputs ...any) error {
 	if t.IsColumnEmpty() {
 		return errs.ErrEmptyColumn

--- a/table/types/types.go
+++ b/table/types/types.go
@@ -204,7 +204,7 @@ func ParseColumnType(type_, precision string) (gpb.ColumnDataType, error) {
 
 func ConvertType(type_ ColumnType) (gpb.ColumnDataType, error) {
 	switch type_ {
-	case BOOLEAN:
+	case BOOLEAN, BOOL:
 		return gpb.ColumnDataType_BOOLEAN, nil
 	case INT8:
 		return gpb.ColumnDataType_INT8, nil
@@ -224,9 +224,9 @@ func ConvertType(type_ ColumnType) (gpb.ColumnDataType, error) {
 		return gpb.ColumnDataType_UINT64, nil
 	case FLOAT32:
 		return gpb.ColumnDataType_FLOAT32, nil
-	case FLOAT64:
+	case FLOAT64, FLOAT:
 		return gpb.ColumnDataType_FLOAT64, nil
-	case BINARY:
+	case BINARY, BYTES:
 		return gpb.ColumnDataType_BINARY, nil
 	case STRING:
 		return gpb.ColumnDataType_STRING, nil

--- a/version.go
+++ b/version.go
@@ -14,4 +14,4 @@
 
 package greptime
 
-const Version = "v0.1.0" // THIS MUST BE THE SAME AS THE VERSION in GitHub release
+const Version = "v0.1.1" // THIS MUST BE THE SAME AS THE VERSION in GitHub release


### PR DESCRIPTION
## What's changed and what's your intention?

`Client` and `StreamClient` can `Create` body directly into GreptimeDB without schema predefined.

```go
	monitors := []monitor{
		{
			ID:          randomId(),
			Host:        "127.0.0.1",
			Memory:      1,
			Cpu:         1.0,
			Temperature: -1,
			Ts:          time1,
			Running:     true,
		},
		{
			ID:          randomId(),
			Host:        "127.0.0.2",
			Memory:      2,
			Cpu:         2.0,
			Temperature: -2,
			Ts:          time2,
			Running:     true,
		},
	}

	resp, err := client.Create(context.Background(), monitors)
```

## Checklist

- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)