### PR TITLE
fix: panic in CloseStream

### DIFF
--- a/client.go
+++ b/client.go
@@ -272,6 +272,10 @@ func (c *Client) StreamDeleteObject(ctx context.Context, body any) error {
 // using client.StreamWrite or client.StreamWriteObject, we need to call client.CloseStream to let
 // GreptimeDB know that we’ve finished writing and are expecting to receive a response.
 func (c *Client) CloseStream(ctx context.Context) (*gpb.AffectedRows, error) {
+	if c.stream == nil {
+		return &gpb.AffectedRows{}, nil
+	}
+
 	resp, err := c.stream.CloseAndRecv()
 	if err != nil {
 		return nil, err

--- a/client_test.go
+++ b/client_test.go
@@ -873,6 +873,14 @@ func TestStreamWrite(t *testing.T) {
 	}
 }
 
+func TestStreamClose(t *testing.T) {
+	lc := newClient()
+
+	affected, err := lc.CloseStream(context.Background())
+	assert.EqualValues(t, 0, affected.GetValue())
+	assert.Nil(t, err)
+}
+
 func TestStreamUpdate(t *testing.T) {
 	loc, err := time.LoadLocation(timezone)
 	assert.Nil(t, err)


### PR DESCRIPTION
## What's changed and what's your intention?

This PR checks whether the stream is nil in `CloseStream` to fix a panic.

It also adds a test for this issue.

## Checklist

- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
https://github.com/GreptimeTeam/greptimedb-ingester-go/issues/36
