### PR TITLE
feat(client): add `Close` method for gRPC connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ cfg.WithKeepalive(time.Second*30, time.Second*5) // keepalive isn't enabled by d
 ### Client
 
 ```go
-cli, err := greptime.NewClient(cfg)
+c, err := greptime.NewClient(cfg)
+...
+defer c.client.Close()
 ```
 
 ### Insert & StreamInsert
@@ -86,7 +88,7 @@ err := tbl.AddRow(2, "127.0.0.2", time.Now())
 ##### Write into GreptimeDB
 
 ```go
-resp, err := cli.Write(context.Background(), tbl)
+resp, err := c.Write(context.Background(), tbl)
 ```
 
 ##### Delete from GreptimeDB
@@ -99,23 +101,23 @@ dtbl.AddTimestampColumn("ts", types.TIMESTAMP_MILLISECOND)
 // timestamp is the time you want to delete row
 err := dtbl.AddRow(1, "127.0.0.1",timestamp)
 
-affected, err := cli.Delete(context.Background(),dtbl)
+affected, err := c.Delete(context.Background(),dtbl)
 ```
 
 ##### Stream Write into GreptimeDB
 
 ```go
-err := cli.StreamWrite(context.Background(), tbl)
+err := c.StreamWrite(context.Background(), tbl)
 ...
-affected, err := cli.CloseStream(ctx)
+affected, err := c.CloseStream(ctx)
 ```
 
 ##### Stream Delete from GreptimeDB
 
 ```go
-err := cli.StreamDelete(context.Background(), tbl)
+err := c.StreamDelete(context.Background(), tbl)
 ...
-affected, err := cli.CloseStream(ctx)
+affected, err := c.CloseStream(ctx)
 ```
 
 #### ORM style
@@ -169,7 +171,7 @@ monitors := []Monitor{
 ##### WriteObject into GreptimeDB
 
 ```go
-resp, err := cli.WriteObject(context.Background(), monitors)
+resp, err := c.WriteObject(context.Background(), monitors)
 ```
 
 ##### DeleteObject in GreptimeDB
@@ -177,15 +179,15 @@ resp, err := cli.WriteObject(context.Background(), monitors)
 ```go
 deleteMonitors := monitors[:1]
 
-affected, err := cli.DeleteObject(context.Background(), deleteMonitors)
+affected, err := c.DeleteObject(context.Background(), deleteMonitors)
 ```
 
 ##### Stream WriteObject into GreptimeDB
 
 ```go
-err := cli.StreamWriteObject(context.Background(), monitors)
+err := c.StreamWriteObject(context.Background(), monitors)
 ...
-affected, err := cli.CloseStream(ctx)
+affected, err := c.CloseStream(ctx)
 ```
 
 ##### Stream DeleteObject in GreptimeDB
@@ -193,9 +195,9 @@ affected, err := cli.CloseStream(ctx)
 ```go
 deleteMonitors := monitors[:1]
 
-err := cli.StreamDeleteObject(context.Background(), deleteMonitors)
+err := c.StreamDeleteObject(context.Background(), deleteMonitors)
 ...
-affected, err := cli.CloseStream(ctx)
+affected, err := c.CloseStream(ctx)
 ```
 
 ## Datatypes supported

--- a/client.go
+++ b/client.go
@@ -309,7 +309,8 @@ func (c *Client) HealthCheck(ctx context.Context) (*gpb.HealthCheckResponse, err
 // Call this method when the client is no longer needed.
 func (c *Client) Close() error {
 	if c.conn != nil {
-		err := c.conn.Close()
+		if err := c.conn.Close(); err != nil {
+		}
 		if err != nil {
 			return err
 		}

--- a/client.go
+++ b/client.go
@@ -310,8 +310,6 @@ func (c *Client) HealthCheck(ctx context.Context) (*gpb.HealthCheckResponse, err
 func (c *Client) Close() error {
 	if c.conn != nil {
 		if err := c.conn.Close(); err != nil {
-		}
-		if err != nil {
 			return err
 		}
 		c.conn = nil

--- a/client.go
+++ b/client.go
@@ -308,16 +308,6 @@ func (c *Client) HealthCheck(ctx context.Context) (*gpb.HealthCheckResponse, err
 // Close terminates the gRPC connection.
 // Call this method when the client is no longer needed.
 func (c *Client) Close() error {
-	// Close the stream if it's open
-	if c.stream != nil {
-		_, err := c.stream.CloseAndRecv()
-		if err != nil {
-			return err
-		}
-		c.stream = nil
-	}
-
-	// Close the connection
 	if c.conn != nil {
 		err := c.conn.Close()
 		if err != nil {

--- a/client_test.go
+++ b/client_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ory/dockertest/v3"
 	dc "github.com/ory/dockertest/v3/docker"
 	"github.com/stretchr/testify/assert"
 	"gorm.io/driver/mysql"

--- a/client_test.go
+++ b/client_test.go
@@ -245,7 +245,6 @@ func init() {
 	log.Printf("Container started, http port: %d, grpc port: %d, mysql port: %d\n", httpPort, grpcPort, mysqlPort)
 
 	cli = newClient()
-	defer cli.Close()
 	db = newMysql()
 }
 
@@ -884,7 +883,6 @@ func TestStreamWrite(t *testing.T) {
 
 func TestStreamClose(t *testing.T) {
 	lc := newClient()
-	defer lc.Close()
 
 	affected, err := lc.CloseStream(context.Background())
 	assert.EqualValues(t, 0, affected.GetValue())

--- a/client_test.go
+++ b/client_test.go
@@ -26,7 +26,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ory/dockertest/v3"
 	dc "github.com/ory/dockertest/v3/docker"
 	"github.com/stretchr/testify/assert"
 	"gorm.io/driver/mysql"
@@ -245,6 +244,7 @@ func init() {
 	log.Printf("Container started, http port: %d, grpc port: %d, mysql port: %d\n", httpPort, grpcPort, mysqlPort)
 
 	cli = newClient()
+	defer cli.Close()
 	db = newMysql()
 }
 
@@ -883,6 +883,7 @@ func TestStreamWrite(t *testing.T) {
 
 func TestStreamClose(t *testing.T) {
 	lc := newClient()
+	defer lc.Close()
 
 	affected, err := lc.CloseStream(context.Background())
 	assert.EqualValues(t, 0, affected.GetValue())

--- a/examples/healthcheck/main.go
+++ b/examples/healthcheck/main.go
@@ -54,6 +54,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("failed to new client: %v", err)
 	}
+	defer c.client.Close()
 
 	_, err = c.client.HealthCheck(context.Background())
 	if err != nil {

--- a/examples/hints/main.go
+++ b/examples/hints/main.go
@@ -182,6 +182,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("failed to new client: %v", err)
 	}
+	defer c.client.Close()
 
 	if err = c.writeWithHint(data[0]); err != nil {
 		log.Fatalf("failed to write data: %v", err)

--- a/examples/jsondata/main.go
+++ b/examples/jsondata/main.go
@@ -72,6 +72,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("failed to new client: %v", err)
 	}
+	defer c.client.Close()
 
 	tb, obj1, obj2, err := initData()
 	if err != nil {

--- a/examples/object/main.go
+++ b/examples/object/main.go
@@ -163,6 +163,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("failed to new client: %v", err)
 	}
+	defer c.client.Close()
 
 	data := initData()
 	// insert

--- a/examples/table/main.go
+++ b/examples/table/main.go
@@ -190,6 +190,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("failed to new client: %v", err)
 	}
+	defer c.client.Close()
 
 	data := initData()
 	// insert


### PR DESCRIPTION
## What's changed and what's your intention?

related issue: https://github.com/GreptimeTeam/greptimedb-ingester-go/issues/76

- Add `*grpc.ClientConn` field to Client struct to maintain gRPC connection.
- Implement `Close()` method.

## Checklist

- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)