### PR TITLE
fix: drain all responses in bulk write Close to avoid premature termination

### DIFF
--- a/bulk/bulk.go
+++ b/bulk/bulk.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sync"
 
 	gpbv1 "github.com/GreptimeTeam/greptime-proto/go/greptime/v1"
 	"github.com/GreptimeTeam/greptimedb-ingester-go/table/types"
@@ -54,9 +55,10 @@ type bulkWriter struct {
 	stream flight.FlightService_DoPutClient
 	writer *flight.Writer
 
-	recvDone chan struct{}   // closed when the recv goroutine exits
-	recvErr  error          // first non-EOF error from recv goroutine
-	rows     uint32         // total affected rows reported by server
+	recvDone chan struct{} // closed when the recv goroutine exits
+	mu       sync.RWMutex
+	recvErr  error  // first non-EOF error from recv goroutine
+	rows     uint32 // total affected rows reported by server
 }
 
 // NewBulkWriter creates a new BulkWriter instance for streaming data to GreptimeDB.
@@ -83,14 +85,18 @@ func (bw *bulkWriter) recvLoop() {
 		resp, err := bw.stream.Recv()
 		if err != nil {
 			if !errors.Is(err, io.EOF) {
+				bw.mu.Lock()
 				bw.recvErr = err
+				bw.mu.Unlock()
 			}
 			return
 		}
 		if resp != nil && len(resp.AppMetadata) > 0 {
 			var meta gpbv1.FlightMetadata
 			if unmarshalErr := proto.Unmarshal(resp.AppMetadata, &meta); unmarshalErr == nil {
+				bw.mu.Lock()
 				bw.rows += meta.GetAffectedRows().GetValue()
+				bw.mu.Unlock()
 			}
 		}
 	}
@@ -98,6 +104,13 @@ func (bw *bulkWriter) recvLoop() {
 
 // Write converts and sends a table of data to GreptimeDB in Arrow format.
 func (bw *bulkWriter) Write(tb *table.Table) error {
+	bw.mu.RLock()
+	err := bw.recvErr
+	bw.mu.RUnlock()
+	if err != nil {
+		return fmt.Errorf("stream already failed: %w", err)
+	}
+
 	converter := types.NewArrowConverter()
 	tableName, err := tb.GetName()
 	if err != nil {

--- a/bulk/bulk.go
+++ b/bulk/bulk.go
@@ -69,6 +69,7 @@ type bulkWriter struct {
 }
 
 // NewBulkWriter creates a new BulkWriter instance for streaming data to GreptimeDB.
+// Callers must call Close when done to release resources and stop the background goroutine.
 func (c *BulkClient) NewBulkWriter(ctx context.Context) (BulkWriter, error) {
 	stream, err := c.client.DoPut(ctx)
 	if err != nil {
@@ -100,7 +101,13 @@ func (bw *bulkWriter) recvLoop() {
 		}
 		if resp != nil && len(resp.AppMetadata) > 0 {
 			var putResp doPutResponse
-			if unmarshalErr := json.Unmarshal(resp.AppMetadata, &putResp); unmarshalErr == nil {
+			if unmarshalErr := json.Unmarshal(resp.AppMetadata, &putResp); unmarshalErr != nil {
+				bw.mu.Lock()
+				if bw.recvErr == nil {
+					bw.recvErr = fmt.Errorf("failed to unmarshal PutResult.AppMetadata: %w", unmarshalErr)
+				}
+				bw.mu.Unlock()
+			} else {
 				bw.mu.Lock()
 				bw.rows += putResp.AffectedRows
 				bw.mu.Unlock()

--- a/bulk/bulk.go
+++ b/bulk/bulk.go
@@ -27,6 +27,7 @@ import (
 	"github.com/apache/arrow/go/v17/arrow/flight"
 	"github.com/apache/arrow/go/v17/arrow/ipc"
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/GreptimeTeam/greptimedb-ingester-go/table"
 )
@@ -52,6 +53,10 @@ type bulkWriter struct {
 	client *BulkClient
 	stream flight.FlightService_DoPutClient
 	writer *flight.Writer
+
+	recvDone chan struct{}   // closed when the recv goroutine exits
+	recvErr  error          // first non-EOF error from recv goroutine
+	rows     uint32         // total affected rows reported by server
 }
 
 // NewBulkWriter creates a new BulkWriter instance for streaming data to GreptimeDB.
@@ -61,10 +66,34 @@ func (c *BulkClient) NewBulkWriter(ctx context.Context) (BulkWriter, error) {
 		return nil, err
 	}
 
-	return &bulkWriter{
-		client: c,
-		stream: stream,
-	}, nil
+	bw := &bulkWriter{
+		client:   c,
+		stream:   stream,
+		recvDone: make(chan struct{}),
+	}
+	go bw.recvLoop()
+	return bw, nil
+}
+
+// recvLoop drains all PutResult messages from the server in the background,
+// accumulating affected rows and capturing the first error.
+func (bw *bulkWriter) recvLoop() {
+	defer close(bw.recvDone)
+	for {
+		resp, err := bw.stream.Recv()
+		if err != nil {
+			if !errors.Is(err, io.EOF) {
+				bw.recvErr = err
+			}
+			return
+		}
+		if resp != nil && len(resp.AppMetadata) > 0 {
+			var meta gpbv1.FlightMetadata
+			if unmarshalErr := proto.Unmarshal(resp.AppMetadata, &meta); unmarshalErr == nil {
+				bw.rows += meta.GetAffectedRows().GetValue()
+			}
+		}
+	}
 }
 
 // Write converts and sends a table of data to GreptimeDB in Arrow format.
@@ -105,11 +134,13 @@ func (bw *bulkWriter) Close() error {
 	}
 
 	if bw.stream != nil {
-		_, err := bw.stream.Recv()
-		if errors.Is(err, io.EOF) {
-			err = nil
+		errs = append(errs, bw.stream.CloseSend())
+		// Wait for recvLoop to drain all server responses (including the
+		// final result sent after the background write task completes).
+		<-bw.recvDone
+		if bw.recvErr != nil {
+			errs = append(errs, bw.recvErr)
 		}
-		errs = append(errs, err, bw.stream.CloseSend())
 		bw.stream = nil
 	}
 
@@ -131,10 +162,11 @@ func (c *BulkClient) BulkWrite(ctx context.Context, tb *table.Table) (*gpbv1.Gre
 		return nil, err
 	}
 
+	writer := bw.(*bulkWriter)
 	return &gpbv1.GreptimeResponse{
 		Response: &gpbv1.GreptimeResponse_AffectedRows{
 			AffectedRows: &gpbv1.AffectedRows{
-				Value: uint32(len(tb.GetRows().Rows)),
+				Value: writer.rows,
 			},
 		},
 	}, nil

--- a/bulk/bulk.go
+++ b/bulk/bulk.go
@@ -54,7 +54,7 @@ func NewBulkClient(conn *grpc.ClientConn) *BulkClient {
 
 type BulkWriter interface {
 	Write(table *table.Table) error
-	Close() error
+	Close() (uint32, error)
 }
 
 type bulkWriter struct {
@@ -145,7 +145,7 @@ func (bw *bulkWriter) Write(tb *table.Table) error {
 
 // Close finalizes the bulk write operation and cleans up resources.
 // This must be called after all writes are completed.
-func (bw *bulkWriter) Close() error {
+func (bw *bulkWriter) Close() (uint32, error) {
 	var errs []error
 
 	if bw.writer != nil {
@@ -164,7 +164,7 @@ func (bw *bulkWriter) Close() error {
 		bw.stream = nil
 	}
 
-	return errors.Join(errs...)
+	return bw.rows, errors.Join(errs...)
 }
 
 // BulkWrite performs a single bulk write operation with the given table data.
@@ -175,18 +175,19 @@ func (c *BulkClient) BulkWrite(ctx context.Context, tb *table.Table) (*gpbv1.Gre
 	}
 
 	if err := bw.Write(tb); err != nil {
-		return nil, errors.Join(err, bw.Close())
+		_, closeErr := bw.Close()
+		return nil, errors.Join(err, closeErr)
 	}
 
-	if err := bw.Close(); err != nil {
+	rows, err := bw.Close()
+	if err != nil {
 		return nil, err
 	}
 
-	writer := bw.(*bulkWriter)
 	return &gpbv1.GreptimeResponse{
 		Response: &gpbv1.GreptimeResponse_AffectedRows{
 			AffectedRows: &gpbv1.AffectedRows{
-				Value: writer.rows,
+				Value: rows,
 			},
 		},
 	}, nil

--- a/bulk/bulk.go
+++ b/bulk/bulk.go
@@ -18,6 +18,7 @@ package bulk
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -28,10 +29,16 @@ import (
 	"github.com/apache/arrow/go/v17/arrow/flight"
 	"github.com/apache/arrow/go/v17/arrow/ipc"
 	"google.golang.org/grpc"
-	"google.golang.org/protobuf/proto"
 
 	"github.com/GreptimeTeam/greptimedb-ingester-go/table"
 )
+
+// doPutResponse mirrors the server-side DoPutResponse (JSON-encoded in PutResult.AppMetadata).
+type doPutResponse struct {
+	RequestID    int64   `json:"request_id"`
+	AffectedRows uint32  `json:"affected_rows"`
+	ElapsedSecs  float64 `json:"elapsed_secs"`
+}
 
 // BulkClient is a client for performing bulk operations with GreptimeDB.
 type BulkClient struct {
@@ -92,10 +99,10 @@ func (bw *bulkWriter) recvLoop() {
 			return
 		}
 		if resp != nil && len(resp.AppMetadata) > 0 {
-			var meta gpbv1.FlightMetadata
-			if unmarshalErr := proto.Unmarshal(resp.AppMetadata, &meta); unmarshalErr == nil {
+			var putResp doPutResponse
+			if unmarshalErr := json.Unmarshal(resp.AppMetadata, &putResp); unmarshalErr == nil {
 				bw.mu.Lock()
-				bw.rows += meta.GetAffectedRows().GetValue()
+				bw.rows += putResp.AffectedRows
 				bw.mu.Unlock()
 			}
 		}


### PR DESCRIPTION
## What's changed and what's your intention?

The server sends an initial ack (affected_rows=0) immediately after parsing the schema, then spawns a background task for the actual write.

The previous `Close()` called `Recv()` only once, capturing the initial ack but missing the background task’s final result, then closed the connection prematurely, causing data loss during writing.

This PR:
  - Start a background `recvLoop` to accumulate all PutResult messages
  - `Close()` now calls CloseSend() then waits for `recvLoop` to finish
  - Return actual affected rows from server in `BulkWrite` response
  - Fail-fast for `Write` when receives error from server. 

## Checklist

- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)