### PR TITLE
fix: datetime type

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -741,14 +741,14 @@ func TestInsertAllDataTypes(t *testing.T) {
 	assert.Nil(t, table.AddFieldColumn("string", types.STRING))
 
 	assert.Nil(t, table.AddFieldColumn("date", types.DATE))
-	assert.Nil(t, table.AddFieldColumn("datetime", types.DATETIME))
+	assert.Nil(t, table.AddFieldColumn("datetime", types.DATETIME)) //nolint:staticcheck // intentional: verify deprecated DATETIME alias still maps to TIMESTAMP_MICROSECOND
 	assert.Nil(t, table.AddFieldColumn("timestamp_second", types.TIMESTAMP_SECOND))
 	assert.Nil(t, table.AddFieldColumn("timestamp_millisecond", types.TIMESTAMP_MILLISECOND))
 	assert.Nil(t, table.AddFieldColumn("timestamp_microsecond", types.TIMESTAMP_MICROSECOND))
 	assert.Nil(t, table.AddFieldColumn("timestamp_nanosecond", types.TIMESTAMP_NANOSECOND))
 
 	assert.Nil(t, table.AddFieldColumn("date_int", types.DATE))
-	assert.Nil(t, table.AddFieldColumn("datetime_int", types.DATETIME))
+	assert.Nil(t, table.AddFieldColumn("datetime_int", types.DATETIME)) //nolint:staticcheck // intentional: verify deprecated DATETIME alias still maps to TIMESTAMP_MICROSECOND
 	assert.Nil(t, table.AddFieldColumn("timestamp_second_int", types.TIMESTAMP_SECOND))
 	assert.Nil(t, table.AddFieldColumn("timestamp_millisecond_int", types.TIMESTAMP_MILLISECOND))
 	assert.Nil(t, table.AddFieldColumn("timestamp_microsecond_int", types.TIMESTAMP_MICROSECOND))

--- a/table/cell/build.go
+++ b/table/cell/build.go
@@ -350,7 +350,11 @@ func BuildDate(v any) (*gpb.Value, error) {
 	return &gpb.Value{ValueData: &gpb.Value_DateValue{DateValue: val}}, nil
 }
 
-// BuildDateTime is replaced by BuildTimestampMicrosecond. Refer to: https://github.com/GreptimeTeam/greptimedb/pull/5506.
+// BuildDateTime builds a DATETIME value.
+//
+// Deprecated: DATETIME is an alias for TIMESTAMP_MICROSECOND. Use BuildTimestampMicrosecond
+// (or another BuildTimestamp* variant) instead.
+// See https://github.com/GreptimeTeam/greptimedb/pull/5506.
 func BuildDateTime(v any) (*gpb.Value, error) {
 	t, i, err := getTimeOrInteger(v)
 	if err != nil {

--- a/table/types/arrow.go
+++ b/table/types/arrow.go
@@ -132,7 +132,8 @@ func (c *ArrowConverter) convertToArrowType(dt gpbv1.ColumnDataType) (arrow.Data
 		return arrow.BinaryTypes.Binary, nil
 	case gpbv1.ColumnDataType_TIMESTAMP_MILLISECOND:
 		return arrow.FixedWidthTypes.Timestamp_ms, nil
-	case gpbv1.ColumnDataType_TIMESTAMP_MICROSECOND:
+	case gpbv1.ColumnDataType_TIMESTAMP_MICROSECOND, gpbv1.ColumnDataType_DATETIME:
+		// DATETIME is a deprecated alias for TIMESTAMP_MICROSECOND (greptimedb PR #5506).
 		return arrow.FixedWidthTypes.Timestamp_us, nil
 	case gpbv1.ColumnDataType_TIMESTAMP_NANOSECOND:
 		return arrow.FixedWidthTypes.Timestamp_ns, nil
@@ -140,8 +141,6 @@ func (c *ArrowConverter) convertToArrowType(dt gpbv1.ColumnDataType) (arrow.Data
 		return arrow.FixedWidthTypes.Timestamp_s, nil
 	case gpbv1.ColumnDataType_DATE:
 		return arrow.FixedWidthTypes.Date32, nil
-	case gpbv1.ColumnDataType_DATETIME:
-		return arrow.FixedWidthTypes.Timestamp_ms, nil
 	case gpbv1.ColumnDataType_TIME_SECOND:
 		return arrow.FixedWidthTypes.Time32s, nil
 	case gpbv1.ColumnDataType_TIME_MILLISECOND:
@@ -265,7 +264,7 @@ func (c *ArrowConverter) fillValue(builder array.Builder, value *gpbv1.Value, da
 				tsValue = value.GetTimestampSecondValue()
 			case gpbv1.ColumnDataType_TIMESTAMP_MILLISECOND:
 				tsValue = value.GetTimestampMillisecondValue()
-			case gpbv1.ColumnDataType_TIMESTAMP_MICROSECOND:
+			case gpbv1.ColumnDataType_TIMESTAMP_MICROSECOND, gpbv1.ColumnDataType_DATETIME:
 				tsValue = value.GetTimestampMicrosecondValue()
 			case gpbv1.ColumnDataType_TIMESTAMP_NANOSECOND:
 				tsValue = value.GetTimestampNanosecondValue()

--- a/table/types/arrow_test.go
+++ b/table/types/arrow_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Greptime Team
+ * Copyright 2026 Greptime Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/table/types/arrow_test.go
+++ b/table/types/arrow_test.go
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2025 Greptime Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package types
+
+import (
+	"testing"
+	"time"
+
+	gpbv1 "github.com/GreptimeTeam/greptime-proto/go/greptime/v1"
+	"github.com/apache/arrow/go/v17/arrow"
+	"github.com/apache/arrow/go/v17/arrow/array"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// DATETIME is a deprecated alias for TIMESTAMP_MICROSECOND (greptimedb PR #5506).
+// Bulk (Arrow) and unary paths must agree on microsecond precision; previously
+// bulk mapped DATETIME to Timestamp_ms and had no fillValue case, so any bulk
+// write of a DATETIME column silently failed.
+func TestConvertToArrowType_DatetimeIsMicrosecond(t *testing.T) {
+	c := NewArrowConverter()
+
+	dtType, err := c.convertToArrowType(gpbv1.ColumnDataType_DATETIME)
+	require.NoError(t, err)
+	assert.Equal(t, arrow.FixedWidthTypes.Timestamp_us, dtType)
+
+	tsType, err := c.convertToArrowType(gpbv1.ColumnDataType_TIMESTAMP_MICROSECOND)
+	require.NoError(t, err)
+	assert.Equal(t, dtType, tsType, "DATETIME must map to the same Arrow type as TIMESTAMP_MICROSECOND")
+}
+
+func TestToArrow_DatetimeColumn(t *testing.T) {
+	now := time.Date(2026, 4, 21, 10, 30, 45, 123456000, time.UTC)
+	micros := now.UnixMicro()
+
+	rows := &gpbv1.Rows{
+		Schema: []*gpbv1.ColumnSchema{
+			{
+				ColumnName:   "ts",
+				SemanticType: gpbv1.SemanticType_TIMESTAMP,
+				Datatype:     gpbv1.ColumnDataType_DATETIME,
+			},
+		},
+		Rows: []*gpbv1.Row{
+			{
+				Values: []*gpbv1.Value{
+					{ValueData: &gpbv1.Value_TimestampMicrosecondValue{TimestampMicrosecondValue: micros}},
+				},
+			},
+			{
+				Values: []*gpbv1.Value{nil},
+			},
+		},
+	}
+
+	record, err := NewArrowConverter().ToArrow(rows)
+	require.NoError(t, err)
+	defer record.Release()
+
+	require.Equal(t, int64(2), record.NumRows())
+	require.Equal(t, int64(1), record.NumCols())
+
+	field := record.Schema().Field(0)
+	assert.Equal(t, arrow.FixedWidthTypes.Timestamp_us, field.Type)
+
+	col, ok := record.Column(0).(*array.Timestamp)
+	require.True(t, ok, "column must be *array.Timestamp")
+	assert.Equal(t, arrow.Timestamp(micros), col.Value(0))
+	assert.True(t, col.IsNull(1))
+}

--- a/table/types/arrow_test.go
+++ b/table/types/arrow_test.go
@@ -29,8 +29,9 @@ import (
 
 // DATETIME is a deprecated alias for TIMESTAMP_MICROSECOND (greptimedb PR #5506).
 // Bulk (Arrow) and unary paths must agree on microsecond precision; previously
-// bulk mapped DATETIME to Timestamp_ms and had no fillValue case, so any bulk
-// write of a DATETIME column silently failed.
+// bulk mapped DATETIME to Timestamp_ms and had no fillValue case for the
+// microsecond timestamp value, so bulk writes of a DATETIME column failed with
+// a propagated conversion error.
 func TestConvertToArrowType_DatetimeIsMicrosecond(t *testing.T) {
 	c := NewArrowConverter()
 

--- a/table/types/types.go
+++ b/table/types/types.go
@@ -59,20 +59,22 @@ type ColumnType int
 //
 // ColumnType has richer types than ColumnDataType in protocol buffer
 const (
-	BOOLEAN               ColumnType = 0
-	INT8                  ColumnType = 1
-	INT16                 ColumnType = 2
-	INT32                 ColumnType = 3
-	INT64                 ColumnType = 4
-	UINT8                 ColumnType = 5
-	UINT16                ColumnType = 6
-	UINT32                ColumnType = 7
-	UINT64                ColumnType = 8
-	FLOAT32               ColumnType = 9
-	FLOAT64               ColumnType = 10
-	BINARY                ColumnType = 11
-	STRING                ColumnType = 12
-	DATE                  ColumnType = 13
+	BOOLEAN ColumnType = 0
+	INT8    ColumnType = 1
+	INT16   ColumnType = 2
+	INT32   ColumnType = 3
+	INT64   ColumnType = 4
+	UINT8   ColumnType = 5
+	UINT16  ColumnType = 6
+	UINT32  ColumnType = 7
+	UINT64  ColumnType = 8
+	FLOAT32 ColumnType = 9
+	FLOAT64 ColumnType = 10
+	BINARY  ColumnType = 11
+	STRING  ColumnType = 12
+	DATE    ColumnType = 13
+	// Deprecated: DATETIME is an alias for TIMESTAMP_MICROSECOND. Use TIMESTAMP_MICROSECOND (or one of the other TIMESTAMP_* variants) instead.
+	// See https://github.com/GreptimeTeam/greptimedb/pull/5506.
 	DATETIME              ColumnType = 14
 	TIMESTAMP_SECOND      ColumnType = 15
 	TIMESTAMP_MILLISECOND ColumnType = 16


### PR DESCRIPTION
## What's changed and what's your intention?

* Align bulk Arrow `DATETIME` handling with the unary path (microseconds), matching its authoritative alias to `TIMESTAMP_MICROSECOND` as in Rust/Java SDKs.
* Deprecated `DATETIME`, which is replaced by `TIMESTAMP_MICROSECOND` in server.

## Checklist

- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)