### PR TITLE
chore: update github runner and golang version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,13 +17,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ["1.22.x", "1.23.x", "1.24.x"]
+        go-version: ["1.24.x", "1.25.x", "1.26.x"]
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go ${{ matrix.go-version }}
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
           cache: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,10 +14,10 @@ env:
 jobs:
   ci:
     if: github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
-        go-version: ["1.24.x", "1.25.x", "1.26.x"]
+        go-version: ["1.26.x"]
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6

--- a/.github/workflows/license.yaml
+++ b/.github/workflows/license.yaml
@@ -19,12 +19,13 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: List file
-      shell: bash
-      run: |
-        cat /home/runner/work/greptimedb-ingester-go/greptimedb-ingester-go/examples/bulkwrite/main.go
-
     - name: Check License Header
       shell: bash
       run: |
+        make format-license
         make check-license
+
+    - name: Diff file
+      shell: bash
+      run: |
+        git diff    

--- a/.github/workflows/license.yaml
+++ b/.github/workflows/license.yaml
@@ -19,6 +19,11 @@ jobs:
       with:
         fetch-depth: 0
 
+    - name: List file
+      shell: bash
+      run: |
+        cat /home/runner/work/greptimedb-ingester-go/greptimedb-ingester-go/examples/bulkwrite/main.go
+
     - name: Check License Header
       shell: bash
       run: |

--- a/.github/workflows/license.yaml
+++ b/.github/workflows/license.yaml
@@ -22,10 +22,4 @@ jobs:
     - name: Check License Header
       shell: bash
       run: |
-        make format-license
         make check-license
-
-    - name: Diff file
-      shell: bash
-      run: |
-        git diff    

--- a/.github/workflows/license.yaml
+++ b/.github/workflows/license.yaml
@@ -20,4 +20,6 @@ jobs:
         fetch-depth: 0
 
     - name: Check License Header
-      uses: korandoru/hawkeye@v6
+      shell: bash
+      run: |
+        make check-license

--- a/.github/workflows/license.yaml
+++ b/.github/workflows/license.yaml
@@ -12,7 +12,7 @@ jobs:
   license-header-check:
     name: license-header-check
     if: github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v6

--- a/.github/workflows/license.yaml
+++ b/.github/workflows/license.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -19,17 +19,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
-          go-version: '1.24.x'
+          go-version: '1.26.x'
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: latest
+          version: v2.11
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -16,7 +16,7 @@ jobs:
   golangci:
     if: github.event.pull_request.draft == false
     name: lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -25,27 +25,7 @@ jobs:
         with:
           go-version: '1.26.x'
 
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9
-        with:
-          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v2.11
-
-          # Optional: working directory, useful for monorepos
-          # working-directory: somedir
-
-          # Optional: golangci-lint command line arguments.
-          args: --timeout 10m -v
-
-          # Optional: show only new issues if it's a pull request. The default value is `false`.
-          # only-new-issues: true
-
-          # Optional: if set to true then the all caching functionality will be complete disabled,
-          #           takes precedence over all other caching options.
-          # skip-cache: true
-
-          # Optional: if set to true then the action don't cache or restore ~/go/pkg.
-          # skip-pkg-cache: true
-
-          # Optional: if set to true then the action don't cache or restore ~/.cache/go-build.
-          # skip-build-cache: true
+      - name: Make lint
+        shell: bash
+        run: |
+          make lint

--- a/.github/workflows/pr-labeling.yaml
+++ b/.github/workflows/pr-labeling.yaml
@@ -17,9 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
-      - uses: actions/labeler@v5
+      - uses: actions/labeler@v6
         with:
           configuration-path: ".github/labeler.yaml"
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
@@ -27,6 +27,6 @@ jobs:
   size-label:
     runs-on: ubuntu-latest
     steps:
-      - uses: pascalgn/size-label-action@v0.5.5
+      - uses: pascalgn/size-label-action@v0.5.7
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/pr-labeling.yaml
+++ b/.github/workflows/pr-labeling.yaml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   labeler:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout sources
         uses: actions/checkout@v6
@@ -25,7 +25,7 @@ jobs:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
 
   size-label:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: pascalgn/size-label-action@v0.5.7
         env:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,123 @@
+version: "2"
+
+# Options for analysis running.
+run:
+  # Timeout for running analysis (default: 1m, set to 10m here)
+  timeout: 10m
+
+  # The default concurrency value is the number of available CPU.
+  concurrency: 4
+
+# output configuration options.
+output:
+  formats:
+    text:
+      path: stdout
+      colors: true
+      print-issued-lines: true
+      print-linter-name: true
+
+linters:
+  # Disable all linters.
+  default: none
+
+  # Directories to skip during analysis.
+  exclusions:
+    paths:
+      - images
+      - .github
+      - examples
+      - hack
+
+  # Enable specific linter
+  # https://golangci-lint.run/usage/linters/#enabled-by-default
+  enable:
+    # Errcheck is a program for checking for unchecked errors in Go code. These unchecked errors can be critical bugs in some cases.
+    - errcheck
+
+    # Vet examines Go source code and reports suspicious constructs, such as Printf calls whose arguments do not align with the format string.
+    - govet
+
+    # Detects when assignments to existing variables are not used.
+    - ineffassign
+
+    # It's a set of rules from staticcheck. It's not the same thing as the staticcheck binary.
+    # The author of staticcheck doesn't support or approve the use of staticcheck as a library inside golangci-lint.
+    - staticcheck
+
+    # Checks whether HTTP response body is closed successfully.
+    - bodyclose
+
+    # Provides diagnostics that check for bugs, performance and style issues.
+    # Extensible without recompilation through dynamic rules.
+    # Dynamic rules are written declaratively with AST patterns, filters, report message and optional suggestion.
+    - gocritic
+
+    # Finds repeated strings that could be replaced by a constant.
+    - goconst
+
+    # Finds commonly misspelled English words in comments.
+    - misspell
+
+    # Finds naked returns in functions greater than a specified function length.
+    - nakedret
+
+  settings:
+    errcheck:
+      # Report about not checking of errors in type assertions: `a := b.(MyStruct)`.
+      # Such cases aren't reported by default.
+      # Default: false
+      check-type-assertions: false
+
+      # List of functions to exclude from checking, where each entry is a single function to exclude.
+      # See https://github.com/kisielk/errcheck#excluding-functions for details.
+      exclude-functions:
+        - (*Client).Close
+
+      # Display function signature instead of selector.
+      # Default: false
+      verbose: true
+
+    staticcheck:
+      # SAxxxx checks in https://staticcheck.dev/docs/configuration/options/#checks
+      # Example (to disable some checks): [ "all", "-SA1000", "-SA1001"]
+      # Default: ["all", "-ST1000", "-ST1003", "-ST1016", "-ST1020", "-ST1021", "-ST1022"]
+      checks:
+        - "all"
+        # Incorrect or missing package comment.
+        # https://staticcheck.dev/docs/checks/#ST1000
+        - "-ST1000"
+        # Poorly chosen identifier.
+        # https://staticcheck.dev/docs/checks/#ST1003
+        - "-ST1003"
+        # Poorly chosen receiver name.
+        # https://staticcheck.dev/docs/checks/#ST1006
+        - "-ST1006"
+        # Use consistent method receiver names.
+        # https://staticcheck.dev/docs/checks/#ST1016
+        - "-ST1016"
+        # The documentation of an exported function should start with the function's name.
+        # https://staticcheck.dev/docs/checks/#ST1020
+        - "-ST1020"
+        # The documentation of an exported type should start with type's name.
+        # https://staticcheck.dev/docs/checks/#ST1021
+        - "-ST1021"
+        # The documentation of an exported variable or constant should start with variable's name.
+        # https://staticcheck.dev/docs/checks/#ST1022
+        - "-ST1022"
+
+    nakedret:
+      # Make an issue if func has more lines of code than this setting, and it has naked returns.
+      # Default: 30
+      max-func-lines: 50
+    goconst:
+      # Minimum number of occurrences to suggest converting to constant (default: 3)
+      min-occurrences: 3
+
+formatters:
+  enable:
+    # Gofmt checks whether code was gofmt-ed. By default, this tool runs with -s option to check for code simplification.
+    - gofmt
+
+    # Handles imports addition/removal (relies on gci for grouping)
+    - goimports

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ## Tool Versions
-KAWKEYE_VERSION ?= v6.0.0
+KAWKEYE_VERSION ?= v6.5.1
 
 .PHONY: hawkeye
 hawkeye: ## Install hawkeye.

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@
 
 ## Tool Versions
 KAWKEYE_VERSION ?= v6.5.1
+GOLANGCI_LINT_VERSION ?= v2.1.6
 
 .PHONY: hawkeye
 hawkeye: ## Install hawkeye.
@@ -30,3 +31,11 @@ format-license: ## Format License Header.
 .PHONY: remove-license
 remove-license: ## Remove License Header.
 	hawkeye remove --config licenserc.toml
+
+.PHONY: lint
+lint: golangci-lint ## Run lint.
+	golangci-lint run -v ./...
+
+.PHONY: golangci-lint
+golangci-lint: ## Install golangci-lint.
+	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ check-license: hawkeye ## Check License Header.
 
 .PHONY: format-license
 format-license: hawkeye ## Format License Header.
-	hawkeye format --config licenserc.toml
+	hawkeye format --config licenserc.toml --fail-if-updated false
 
 .PHONY: remove-license
 remove-license: ## Remove License Header.

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ hawkeye: ## Install hawkeye.
 	curl --proto '=https' --tlsv1.2 -LsSf https://github.com/korandoru/hawkeye/releases/download/${KAWKEYE_VERSION}/hawkeye-installer.sh | sh
 
 .PHONY: check-license
-check-license: ## Check License Header.
+check-license: hawkeye ## Check License Header.
 	hawkeye check --config licenserc.toml
 
 .PHONY: format-license

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ check-license: hawkeye ## Check License Header.
 	hawkeye check --config licenserc.toml
 
 .PHONY: format-license
-format-license: ## Format License Header.
+format-license: hawkeye ## Format License Header.
 	hawkeye format --config licenserc.toml
 
 .PHONY: remove-license

--- a/client_test.go
+++ b/client_test.go
@@ -36,7 +36,7 @@ import (
 	"github.com/GreptimeTeam/greptimedb-ingester-go/table/types"
 )
 
-//TODO(yuanbohan):
+// TODO(yuanbohan):
 // unmatched length of columns in rows and columns in schema
 // support pointer
 // timeout test

--- a/config.go
+++ b/config.go
@@ -108,8 +108,8 @@ func (c *Config) WithMetricsEnabled(b bool) *Config {
 }
 
 // WithMeterProvider provides a MeterProvider for SDK.
-// If metrics colleciton is not enabled, then this option has no effect.
-// If metrics colleciton is enabled and this option is not provide.
+// If metrics collection is not enabled, then this option has no effect.
+// If metrics collection is enabled and this option is not provide.
 // the global MeterProvider will be used.
 func (c *Config) WithMeterProvider(p metric.MeterProvider) *Config {
 	c.telemetry.Metrics.MeterProvider = p
@@ -123,8 +123,8 @@ func (c *Config) WithTracesEnabled(b bool) *Config {
 }
 
 // WithTraceProvider provides a TracerProvider for SDK.
-// If traces colleciton is not enabled, then this option has no effect.
-// If traces colleciton is enabled and this option is not provide.
+// If traces collection is not enabled, then this option has no effect.
+// If traces collection is enabled and this option is not provide.
 // the global MeterProvider will be used.
 func (c *Config) WithTraceProvider(p trace.TracerProvider) *Config {
 	c.telemetry.Traces.TracerProvider = p

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/GreptimeTeam/greptimedb-ingester-go
 
-go 1.24.0
+go 1.26.0
 
 require (
 	github.com/GreptimeTeam/greptime-proto v0.15.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/GreptimeTeam/greptimedb-ingester-go
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/GreptimeTeam/greptime-proto v0.15.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/GreptimeTeam/greptimedb-ingester-go
 
-go 1.26.0
+go 1.25.0
 
 require (
 	github.com/GreptimeTeam/greptime-proto v0.15.0

--- a/hack/license-header.txt
+++ b/hack/license-header.txt
@@ -1,4 +1,4 @@
-Copyright {{attrs.git_file_created_year if attrs.git_file_created_year else attrs.disk_file_created_year }} {{props["copyrightOwner"]}}
+Copyright {{attrs.git_file_created_year}} {{props["copyrightOwner"]}}
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/hack/license-header.txt
+++ b/hack/license-header.txt
@@ -1,4 +1,4 @@
-Copyright {{attrs.git_file_created_year}} {{props["copyrightOwner"]}}
+Copyright {{attrs.git_file_created_year if attrs.git_file_created_year else attrs.disk_file_created_year }} {{props["copyrightOwner"]}}
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/licenserc.toml
+++ b/licenserc.toml
@@ -13,6 +13,10 @@ includes = [
     'Makefile'
 ]
 
+excludes = [
+    '**/.git/**'
+]
+
 [properties]
 copyrightOwner = "Greptime Team"
 

--- a/licenserc.toml
+++ b/licenserc.toml
@@ -16,9 +16,9 @@ excludes = [
     '**/.git/**'
 ]
 
-[properties]
-copyrightOwner = "Greptime Team"
-
 [git]
 attrs = 'enable'
 ignore = 'auto'
+
+[properties]
+copyrightOwner = "Greptime Team"

--- a/licenserc.toml
+++ b/licenserc.toml
@@ -13,7 +13,8 @@ includes = [
 ]
 
 excludes = [
-    '**/.git/**'
+    '**/.git/**',
+    'examples/**'
 ]
 
 [git]

--- a/licenserc.toml
+++ b/licenserc.toml
@@ -1,6 +1,5 @@
 # manually check and fix the license declaration
 #
-# make hawkeye
 # make check-license
 # make format-license
 

--- a/options/tls.go
+++ b/options/tls.go
@@ -32,8 +32,8 @@ type TlsOption struct {
 	// ClientKeyPath, ClientCertPath string // mTLS
 }
 
-func NewTlsOption(InsecureSkipVerify bool) TlsOption {
-	return TlsOption{InsecureSkipVerify: InsecureSkipVerify}
+func NewTlsOption(insecureSkipVerify bool) TlsOption {
+	return TlsOption{InsecureSkipVerify: insecureSkipVerify}
 }
 
 func (opt TlsOption) Build() grpc.DialOption {

--- a/util/util.go
+++ b/util/util.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Greptime Team
+ * Copyright 2024 Greptime Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Greptime Team
+ * Copyright 2024 Greptime Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
## What's changed and what's your intention?

- Update github runner version
- Update golang version to 1.26
- Using [golangci-lint](https://github.com/golangci/golangci-lint) replace golang-lint-action.
- Fixed license check fail in: https://github.com/GreptimeTeam/greptimedb-ingester-go/actions/runs/24721451067

## Checklist

- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)