### PR TITLE
feat: supports multi endpoints and fix timestamp timezone

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,7 @@ jobs:
         run: go build -v ./...
 
       - name: Test
-        run: go test -v ./... -race -covermode=atomic -coverprofile=coverage.out
+        run: go test -v ./... -race -covermode=atomic -coverprofile=coverage.out -tags=integration
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5

--- a/README.md
+++ b/README.md
@@ -45,6 +45,28 @@ cfg.WithInsecure(false) // default insecure=true
 cfg.WithKeepalive(time.Second*30, time.Second*5) // keepalive isn't enabled by default
 ```
 
+##### Multiple endpoints
+
+Configure several GreptimeDB endpoints to spread writes across an HA cluster.
+Unary calls (`Write`, `Delete`, `HealthCheck`, `BulkWrite`) pick an endpoint
+per call through the configured picker. A streaming session started by
+`StreamWrite` / `StreamDelete` binds to one endpoint until `CloseStream`; if
+that endpoint fails mid-stream the Send returns the error and the next
+`StreamWrite` picks a fresh endpoint. Auth, TLS, keepalive and telemetry are
+shared across all endpoints.
+
+```go
+import "github.com/GreptimeTeam/greptimedb-ingester-go/loadbalancer"
+
+cfg := greptime.NewConfig().
+    WithDatabase("<database>").
+    WithEndpoints("host1:4001", "host2:4001", "host3:4001").
+    WithLoadBalancer(loadbalancer.NewRoundRobin()) // default is NewRandom()
+```
+
+See [`examples/multi_endpoint`](examples/multi_endpoint/main.go) for a runnable
+demo that reports per-endpoint dispatch counts.
+
 ### Client
 
 ```go

--- a/client.go
+++ b/client.go
@@ -18,11 +18,14 @@ package greptime
 
 import (
 	"context"
+	"fmt"
+	"net"
+	"sync"
 
 	gpb "github.com/GreptimeTeam/greptime-proto/go/greptime/v1"
-	"google.golang.org/grpc"
 
-	"github.com/GreptimeTeam/greptimedb-ingester-go/bulk"
+	"github.com/GreptimeTeam/greptimedb-ingester-go/internal/pool"
+	"github.com/GreptimeTeam/greptimedb-ingester-go/loadbalancer"
 	"github.com/GreptimeTeam/greptimedb-ingester-go/request"
 	"github.com/GreptimeTeam/greptimedb-ingester-go/request/header"
 	"github.com/GreptimeTeam/greptimedb-ingester-go/schema"
@@ -31,47 +34,58 @@ import (
 )
 
 // Client helps to write data into GreptimeDB. A Client is safe for concurrent
-// use by multiple goroutines,you can have one Client instance in your application.
+// use by multiple goroutines; one instance per application is typical.
+//
+// When configured with multiple endpoints via Config.WithEndpoints, unary
+// calls (Write, Delete, HealthCheck, BulkWrite) pick an endpoint per call
+// through the configured loadbalancer.Picker. A streaming session opened by
+// StreamWrite/StreamDelete binds to a single endpoint until CloseStream;
+// if that endpoint fails mid-stream, the Send returns the underlying error
+// and the next StreamWrite call picks a fresh endpoint to open a new stream.
 type Client struct {
-	cfg               *Config
-	conn              *grpc.ClientConn
-	client            gpb.GreptimeDatabaseClient
-	stream            gpb.GreptimeDatabase_HandleRequestsClient
-	healthCheckClient gpb.HealthCheckClient
-	bulkClient        *bulk.BulkClient
+	cfg  *Config
+	pool *pool.Pool
+
+	streamMu sync.Mutex
+	stream   gpb.GreptimeDatabase_HandleRequestsClient
 }
 
-// NewClient helps to create the greptimedb client, which will be responsible write data into GreptimeDB.
+// NewClient creates the greptimedb client responsible for writing data into
+// GreptimeDB. Endpoints configured via WithEndpoints take precedence over
+// Host:Port; each entry must be a "host:port" string.
 func NewClient(cfg *Config) (*Client, error) {
-	conn, err := grpc.NewClient(cfg.endpoint(), cfg.build()...)
+	addrs := cfg.resolveEndpoints()
+	if len(addrs) == 0 {
+		return nil, fmt.Errorf("greptime: no endpoint configured; pass a host to NewConfig or call WithEndpoints")
+	}
+	for _, addr := range addrs {
+		if _, _, err := net.SplitHostPort(addr); err != nil {
+			return nil, fmt.Errorf("greptime: invalid endpoint %q: %w", addr, err)
+		}
+	}
+
+	picker := cfg.picker
+	if picker == nil {
+		picker = loadbalancer.NewRandom()
+	}
+
+	p, err := pool.New(addrs, picker, cfg.build())
 	if err != nil {
 		return nil, err
 	}
 
-	client := gpb.NewGreptimeDatabaseClient(conn)
-	healthCheckClient := gpb.NewHealthCheckClient(conn)
-	bulkClient := bulk.NewBulkClient(conn)
-
-	return &Client{
-		cfg:               cfg,
-		client:            client,
-		conn:              conn,
-		healthCheckClient: healthCheckClient,
-		bulkClient:        bulkClient,
-	}, nil
+	return &Client{cfg: cfg, pool: p}, nil
 }
 
-// submit is to build request and send it to GreptimeDB.
-// The operations can be set:
-//   - INSERT
-//   - DELETE
+// submit builds a request and dispatches it to a picked endpoint. picking
+// fresh per call keeps the path retry-friendly once a retry layer lands.
 func (c *Client) submit(ctx context.Context, operation types.Operation, tables ...*table.Table) (*gpb.GreptimeResponse, error) {
 	header_ := header.New(c.cfg.Database).WithAuth(c.cfg.Username, c.cfg.Password)
 	request_, err := request.New(header_, operation, tables...).Build()
 	if err != nil {
 		return nil, err
 	}
-	return c.client.Handle(ctx, request_)
+	return c.pool.Pick().DB.Handle(ctx, request_)
 }
 
 // Write is to write the data into GreptimeDB via explicit schema.
@@ -168,17 +182,25 @@ func (c *Client) DeleteObject(ctx context.Context, obj any) (*gpb.GreptimeRespon
 	return c.submit(ctx, types.DELETE, tbl)
 }
 
-// streamSubmit is to build stream request and send it to GreptimeDB.
-// The operations can be set:
-//   - INSERT
-//   - DELETE
+// streamSubmit lazily opens a bidirectional stream against a picked endpoint
+// and sends the request on it. The stream is cached until CloseStream or
+// until a Send error is surfaced; on error we clear the cache so that the
+// next call re-picks and rebuilds (matches the TypeScript ingester and
+// avoids silent failover that could gap or duplicate rows).
+//
+// The mutex serializes stream construction (gRPC Send is not itself safe for
+// concurrent calls) and also fixes a pre-existing TOCTOU race on the cached
+// stream.
 func (c *Client) streamSubmit(ctx context.Context, operation types.Operation, tables ...*table.Table) error {
+	c.streamMu.Lock()
+	defer c.streamMu.Unlock()
+
 	if c.stream == nil {
-		stream, err := c.client.HandleRequests(ctx)
+		s, err := c.pool.Pick().DB.HandleRequests(ctx)
 		if err != nil {
 			return err
 		}
-		c.stream = stream
+		c.stream = s
 	}
 
 	header_ := header.New(c.cfg.Database).WithAuth(c.cfg.Username, c.cfg.Password)
@@ -186,7 +208,12 @@ func (c *Client) streamSubmit(ctx context.Context, operation types.Operation, ta
 	if err != nil {
 		return err
 	}
-	return c.stream.Send(request_)
+	if err := c.stream.Send(request_); err != nil {
+		// Clear the broken stream so the next call rebuilds on a fresh pick.
+		c.stream = nil
+		return err
+	}
+	return nil
 }
 
 // StreamWrite is to send the data into GreptimeDB via explicit schema.
@@ -284,7 +311,10 @@ func (c *Client) StreamDeleteObject(ctx context.Context, body any) error {
 // CloseStream closes the stream. Once we’ve finished writing our client’s requests to the stream
 // using client.StreamWrite or client.StreamWriteObject, we need to call client.CloseStream to let
 // GreptimeDB know that we’ve finished writing and are expecting to receive a response.
-func (c *Client) CloseStream(ctx context.Context) (*gpb.AffectedRows, error) {
+func (c *Client) CloseStream(_ context.Context) (*gpb.AffectedRows, error) {
+	c.streamMu.Lock()
+	defer c.streamMu.Unlock()
+
 	if c.stream == nil {
 		return &gpb.AffectedRows{}, nil
 	}
@@ -298,27 +328,29 @@ func (c *Client) CloseStream(ctx context.Context) (*gpb.AffectedRows, error) {
 	return resp.GetAffectedRows(), nil
 }
 
-// HealthCheck will check GreptimeDB health status.
+// HealthCheck will check GreptimeDB health status. With multiple endpoints
+// configured, HealthCheck probes whichever endpoint the picker returns for
+// this call, not every endpoint.
 func (c *Client) HealthCheck(ctx context.Context) (*gpb.HealthCheckResponse, error) {
 	req := &gpb.HealthCheckRequest{}
-	resp, err := c.healthCheckClient.HealthCheck(ctx, req)
-	if err != nil {
-		return nil, err
-	}
-
-	return resp, nil
+	return c.pool.Pick().Health.HealthCheck(ctx, req)
 }
 
-// Close terminates the gRPC connection.
-// Call this method when the client is no longer needed.
+// Close terminates all underlying gRPC connections. Any active stream is
+// aborted by the connection teardown; callers that need a graceful
+// half-close must call CloseStream first. Call this method when the
+// client is no longer needed.
 func (c *Client) Close() error {
-	if c.conn != nil {
-		if err := c.conn.Close(); err != nil {
+	c.streamMu.Lock()
+	c.stream = nil
+	c.streamMu.Unlock()
+
+	if c.pool != nil {
+		if err := c.pool.Close(); err != nil {
 			return err
 		}
-		c.conn = nil
+		c.pool = nil
 	}
-
 	return nil
 }
 
@@ -326,5 +358,5 @@ func (c *Client) Close() error {
 // It sends the entire table data in a single batch, which is more efficient for large datasets compared to row-by-row writes.
 // The table must have columns and rows properly defined before calling this method.
 func (c *Client) BulkWrite(ctx context.Context, table *table.Table) (*gpb.GreptimeResponse, error) {
-	return c.bulkClient.BulkWrite(ctx, table)
+	return c.pool.Pick().Bulk.BulkWrite(ctx, table)
 }

--- a/client.go
+++ b/client.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net"
 	"sync"
+	"sync/atomic"
 
 	gpb "github.com/GreptimeTeam/greptime-proto/go/greptime/v1"
 
@@ -45,6 +46,12 @@ import (
 type Client struct {
 	cfg  *Config
 	pool *pool.Pool
+
+	// closed guards Close against repeated invocations. The pool pointer
+	// itself is intentionally left stable after Close so that any RPC still
+	// in flight — or a post-close misuse — surfaces as a gRPC transport
+	// error rather than a nil-pointer dereference.
+	closed atomic.Bool
 
 	streamMu sync.Mutex
 	stream   gpb.GreptimeDatabase_HandleRequestsClient
@@ -339,19 +346,18 @@ func (c *Client) HealthCheck(ctx context.Context) (*gpb.HealthCheckResponse, err
 // Close terminates all underlying gRPC connections. Any active stream is
 // aborted by the connection teardown; callers that need a graceful
 // half-close must call CloseStream first. Call this method when the
-// client is no longer needed.
+// client is no longer needed. Close is idempotent; RPCs issued after
+// Close fail with a gRPC transport error rather than panicking.
 func (c *Client) Close() error {
+	if !c.closed.CompareAndSwap(false, true) {
+		return nil
+	}
+
 	c.streamMu.Lock()
 	c.stream = nil
 	c.streamMu.Unlock()
 
-	if c.pool != nil {
-		if err := c.pool.Close(); err != nil {
-			return err
-		}
-		c.pool = nil
-	}
-	return nil
+	return c.pool.Close()
 }
 
 // BulkWrite performs a high-efficiency bulk data write operation to GreptimeDB using Apache Arrow format.

--- a/client_test.go
+++ b/client_test.go
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+//go:build integration
+
 package greptime
 
 import (
@@ -32,6 +34,7 @@ import (
 	"gorm.io/driver/mysql"
 	"gorm.io/gorm"
 
+	"github.com/GreptimeTeam/greptimedb-ingester-go/loadbalancer"
 	tbl "github.com/GreptimeTeam/greptimedb-ingester-go/table"
 	"github.com/GreptimeTeam/greptimedb-ingester-go/table/types"
 )
@@ -1290,4 +1293,55 @@ func TestBulkWriteMonitors(t *testing.T) {
 	for i, monitor_ := range monitors_ {
 		assert.Equal(t, monitors[i], monitor_)
 	}
+}
+
+// TestMultiEndpointWrite exercises the multi-endpoint dispatch path against
+// the real GreptimeDB container. It configures the same address twice so
+// every Pick resolves to the live server, and switches the picker to
+// round-robin so the test is deterministic without needing a second
+// container. This verifies the pool + picker wiring does not regress the
+// single-container insert path.
+func TestMultiEndpointWrite(t *testing.T) {
+	addr := fmt.Sprintf("%s:%d", host, grpcPort)
+	cfg := NewConfig().
+		WithDatabase(database).
+		WithKeepalive(30*time.Second, 5*time.Second).
+		WithEndpoints(addr, addr).
+		WithLoadBalancer(loadbalancer.NewRoundRobin())
+
+	multi, err := NewClient(cfg)
+	assert.Nil(t, err)
+	defer multi.Close()
+
+	ts := time.Now()
+	monitors := []monitor{
+		{ID: randomId(), Host: "127.0.0.1", Memory: 1, Cpu: 1.0, Temperature: -1, Ts: ts, Running: true},
+		{ID: randomId(), Host: "127.0.0.2", Memory: 2, Cpu: 2.0, Temperature: -2, Ts: ts, Running: true},
+	}
+
+	table, err := tbl.New(monitorTableName)
+	assert.Nil(t, err)
+	assert.Nil(t, table.AddTagColumn("id", types.INT64))
+	assert.Nil(t, table.AddTagColumn("host", types.STRING))
+	assert.Nil(t, table.AddFieldColumn("memory", types.UINT64))
+	assert.Nil(t, table.AddFieldColumn("cpu", types.FLOAT64))
+	assert.Nil(t, table.AddFieldColumn("temperature", types.INT64))
+	assert.Nil(t, table.AddFieldColumn("running", types.BOOLEAN))
+	assert.Nil(t, table.AddTimestampColumn("ts", types.TIMESTAMP_MILLISECOND))
+
+	for _, m := range monitors {
+		assert.Nil(t, table.AddRow(m.ID, m.Host, m.Memory, m.Cpu, m.Temperature, m.Running, m.Ts))
+	}
+
+	// Fire multiple writes so round-robin rotates through both (duplicate)
+	// endpoints at least once each.
+	for i := 0; i < 4; i++ {
+		resp, err := multi.Write(context.Background(), table)
+		assert.Nil(t, err)
+		assert.Zero(t, resp.GetHeader().GetStatus().GetStatusCode())
+	}
+
+	hcResp, err := multi.HealthCheck(context.Background())
+	assert.Nil(t, err)
+	assert.NotNil(t, hcResp)
 }

--- a/config.go
+++ b/config.go
@@ -18,6 +18,7 @@ package greptime
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"go.opentelemetry.io/otel/metric"
@@ -25,6 +26,7 @@ import (
 
 	"google.golang.org/grpc"
 
+	"github.com/GreptimeTeam/greptimedb-ingester-go/loadbalancer"
 	"github.com/GreptimeTeam/greptimedb-ingester-go/options"
 )
 
@@ -43,16 +45,31 @@ type Config struct {
 	Password string
 	Database string // the default database
 
+	// endpoints, when non-empty, overrides Host:Port. Each entry is a
+	// "host:port" string. Populated via WithEndpoints.
+	endpoints []string
+
+	// picker selects an endpoint per RPC when more than one is configured.
+	// Defaults to loadbalancer.NewRandom() at client construction time.
+	picker loadbalancer.Picker
+
 	tls     *options.TlsOption
 	options []grpc.DialOption
 
 	telemetry *options.TelemetryOptions
 }
 
-// NewConfig helps to init Config with host only
-func NewConfig(host string) *Config {
-	return &Config{
-		Host: host,
+// NewConfig initializes a Config.
+//
+//   - NewConfig() — no endpoint yet; caller must call WithEndpoints.
+//   - NewConfig("host") — single-endpoint legacy form; port defaults to
+//     4001 and can be changed with WithPort.
+//   - NewConfig("host:port") — single-endpoint shorthand equivalent to
+//     NewConfig().WithEndpoints("host:port"). WithPort has no effect.
+//   - NewConfig("host1:4001", "host2:4001", ...) — equivalent to
+//     NewConfig().WithEndpoints(args...). WithPort has no effect.
+func NewConfig(hosts ...string) *Config {
+	cfg := &Config{
 		Port: 4001,
 
 		telemetry: options.NewTelemetryOptions(),
@@ -60,6 +77,22 @@ func NewConfig(host string) *Config {
 			options.NewUserAgentOption(version).Build(),
 		},
 	}
+	switch len(hosts) {
+	case 0:
+		// nothing to do; caller will set endpoints via WithEndpoints.
+	case 1:
+		// An argument containing ':' is treated as a "host:port" endpoint
+		// rather than a bare host; this avoids silently producing
+		// "host:port:4001" through Host+Port concatenation.
+		if strings.Contains(hosts[0], ":") {
+			cfg.WithEndpoints(hosts[0])
+		} else {
+			cfg.Host = hosts[0]
+		}
+	default:
+		cfg.WithEndpoints(hosts...)
+	}
+	return cfg
 }
 
 // WithPort set the Port field. Do not change it if you have no idea what it is.
@@ -138,8 +171,40 @@ func (c *Config) WithDialOption(opt grpc.DialOption) *Config {
 	return c
 }
 
-func (c *Config) endpoint() string {
-	return fmt.Sprintf("%s:%d", c.Host, c.Port)
+// WithEndpoints configures multiple GreptimeDB endpoints for client-side
+// load balancing. Each endpoint must be a "host:port" string. When at
+// least one endpoint is provided, Host and Port are ignored. Passing no
+// arguments is a no-op and the client falls back to Host:Port.
+//
+// Authentication, TLS, keepalive, telemetry and any dial options are
+// shared across all endpoints; per-endpoint overrides are not supported.
+func (c *Config) WithEndpoints(endpoints ...string) *Config {
+	if len(endpoints) > 0 {
+		c.endpoints = append([]string(nil), endpoints...)
+	}
+	return c
+}
+
+// WithLoadBalancer sets the load-balancing strategy used when more than one
+// endpoint is configured. Defaults to loadbalancer.NewRandom() when unset.
+// Has no observable effect when only a single endpoint is in use.
+func (c *Config) WithLoadBalancer(picker loadbalancer.Picker) *Config {
+	c.picker = picker
+	return c
+}
+
+// resolveEndpoints returns the configured endpoints, falling back to
+// [Host:Port] when WithEndpoints was not called. Returns an empty slice
+// when neither a Host nor endpoints were set, which NewClient reports as a
+// configuration error.
+func (c *Config) resolveEndpoints() []string {
+	if len(c.endpoints) > 0 {
+		return c.endpoints
+	}
+	if c.Host == "" {
+		return nil
+	}
+	return []string{fmt.Sprintf("%s:%d", c.Host, c.Port)}
 }
 
 func (c *Config) build() []grpc.DialOption {

--- a/config.go
+++ b/config.go
@@ -18,7 +18,7 @@ package greptime
 
 import (
 	"fmt"
-	"strings"
+	"net"
 	"time"
 
 	"go.opentelemetry.io/otel/metric"
@@ -81,10 +81,11 @@ func NewConfig(hosts ...string) *Config {
 	case 0:
 		// nothing to do; caller will set endpoints via WithEndpoints.
 	case 1:
-		// An argument containing ':' is treated as a "host:port" endpoint
-		// rather than a bare host; this avoids silently producing
-		// "host:port:4001" through Host+Port concatenation.
-		if strings.Contains(hosts[0], ":") {
+		// If the argument parses as "host:port", treat it as an explicit
+		// endpoint; otherwise keep the legacy bare-host semantics so that
+		// NewConfig("127.0.0.1") and NewConfig("[::1]") both still work
+		// with WithPort.
+		if _, _, err := net.SplitHostPort(hosts[0]); err == nil {
 			cfg.WithEndpoints(hosts[0])
 		} else {
 			cfg.Host = hosts[0]

--- a/config_test.go
+++ b/config_test.go
@@ -45,6 +45,19 @@ func TestNewConfigSingleHostRespectsWithPort(t *testing.T) {
 	assert.Equal(t, []string{"h:14001"}, cfg.resolveEndpoints())
 }
 
+func TestNewConfigSingleArgIPv6BareHost(t *testing.T) {
+	cfg := NewConfig("[::1]")
+	assert.Equal(t, "[::1]", cfg.Host,
+		"bracketed IPv6 without a port must stay in the legacy bare-host form")
+	assert.Equal(t, []string{"[::1]:4001"}, cfg.resolveEndpoints())
+}
+
+func TestNewConfigSingleArgIPv6HostPortShorthand(t *testing.T) {
+	cfg := NewConfig("[::1]:4001")
+	assert.Equal(t, "", cfg.Host, "host:port arg must not populate Host")
+	assert.Equal(t, []string{"[::1]:4001"}, cfg.resolveEndpoints())
+}
+
 func TestNewConfigSingleArgHostPortShorthand(t *testing.T) {
 	cfg := NewConfig("h1:5001")
 	assert.Equal(t, "", cfg.Host, "host:port arg must not populate Host")

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2026 Greptime Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package greptime
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/GreptimeTeam/greptimedb-ingester-go/loadbalancer"
+)
+
+func TestNewConfigNoArgs(t *testing.T) {
+	cfg := NewConfig()
+	assert.Equal(t, "", cfg.Host)
+	assert.Equal(t, 4001, cfg.Port)
+	assert.Empty(t, cfg.resolveEndpoints(),
+		"no host and no endpoints should resolve to nothing so NewClient can report a clear error")
+}
+
+func TestNewConfigSingleHostLegacyForm(t *testing.T) {
+	cfg := NewConfig("greptimedb.example.com")
+	assert.Equal(t, "greptimedb.example.com", cfg.Host)
+	assert.Equal(t, 4001, cfg.Port)
+	assert.Equal(t, []string{"greptimedb.example.com:4001"}, cfg.resolveEndpoints())
+}
+
+func TestNewConfigSingleHostRespectsWithPort(t *testing.T) {
+	cfg := NewConfig("h").WithPort(14001)
+	assert.Equal(t, []string{"h:14001"}, cfg.resolveEndpoints())
+}
+
+func TestNewConfigSingleArgHostPortShorthand(t *testing.T) {
+	cfg := NewConfig("h1:5001")
+	assert.Equal(t, "", cfg.Host, "host:port arg must not populate Host")
+	assert.Equal(t, []string{"h1:5001"}, cfg.resolveEndpoints(),
+		"single host:port arg must behave like WithEndpoints, not Host+Port concatenation")
+}
+
+func TestNewConfigSingleArgHostPortIgnoresWithPort(t *testing.T) {
+	cfg := NewConfig("h1:5001").WithPort(9999)
+	assert.Equal(t, []string{"h1:5001"}, cfg.resolveEndpoints(),
+		"WithPort must not override an explicit host:port endpoint")
+}
+
+func TestNewConfigMultiArgShorthand(t *testing.T) {
+	cfg := NewConfig("h1:4001", "h2:4001", "h3:4001")
+	assert.Equal(t, "", cfg.Host, "multi-arg form must not set Host")
+	assert.Equal(t, []string{"h1:4001", "h2:4001", "h3:4001"}, cfg.resolveEndpoints())
+}
+
+func TestNewConfigMultiArgEquivalentToWithEndpoints(t *testing.T) {
+	a := NewConfig("h1:4001", "h2:4001")
+	b := NewConfig().WithEndpoints("h1:4001", "h2:4001")
+	assert.Equal(t, a.resolveEndpoints(), b.resolveEndpoints())
+}
+
+func TestWithEndpointsOverridesHostPort(t *testing.T) {
+	cfg := NewConfig("legacy").WithPort(9999).WithEndpoints("h1:4001", "h2:4001")
+	assert.Equal(t, []string{"h1:4001", "h2:4001"}, cfg.resolveEndpoints(),
+		"explicit endpoints must win over Host:Port")
+}
+
+func TestWithEndpointsEmptyCallIsNoop(t *testing.T) {
+	cfg := NewConfig("h1").WithEndpoints()
+	assert.Equal(t, []string{"h1:4001"}, cfg.resolveEndpoints(),
+		"WithEndpoints() with no args must not clobber a previously configured host")
+}
+
+func TestWithEndpointsCopiesSlice(t *testing.T) {
+	input := []string{"h1:4001", "h2:4001"}
+	cfg := NewConfig().WithEndpoints(input...)
+	input[0] = "mutated:0"
+	assert.Equal(t, []string{"h1:4001", "h2:4001"}, cfg.resolveEndpoints(),
+		"mutating the caller's slice must not affect Config")
+}
+
+func TestWithLoadBalancerStoresPicker(t *testing.T) {
+	picker := loadbalancer.NewRoundRobin()
+	cfg := NewConfig("h").WithLoadBalancer(picker)
+	assert.Same(t, picker, cfg.picker)
+}
+
+func TestNewClientNoEndpointConfigured(t *testing.T) {
+	_, err := NewClient(NewConfig())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no endpoint configured")
+}
+
+func TestNewClientInvalidEndpoint(t *testing.T) {
+	_, err := NewClient(NewConfig().WithEndpoints("missing-port"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid endpoint")
+}
+
+func TestNewClientWithoutPickerLeavesCfgUntouched(t *testing.T) {
+	// grpc.NewClient is non-blocking so this succeeds without a real server.
+	c, err := NewClient(NewConfig().WithEndpoints("127.0.0.1:1", "127.0.0.1:2"))
+	require.NoError(t, err)
+	defer func() { _ = c.Close() }()
+	// NewClient must not mutate cfg.picker when substituting the default;
+	// behavior of the default picker is covered in loadbalancer tests.
+	assert.Nil(t, c.cfg.picker, "cfg.picker should be untouched; NewClient picks the default internally")
+	assert.Len(t, c.pool.Addrs(), 2)
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -20,6 +20,7 @@ docker run --rm -p 4000-4003:4000-4003 \
 - [hints](hints/README.md)
 - [jsondata](jsondata/README.md)
 - [bulkwrite](bulkwrite/README.md)
+- [multi_endpoint](multi_endpoint/main.go) — write against multiple GreptimeDB endpoints with client-side load balancing
 
 ## Query
 

--- a/examples/multi_endpoint/main.go
+++ b/examples/multi_endpoint/main.go
@@ -14,27 +14,12 @@
  * limitations under the License.
  */
 
-// Package main demonstrates writing to multiple GreptimeDB endpoints with
-// client-side load balancing.
-//
-// Usage:
-//
-//	GREPTIMEDB_ENDPOINTS=host1:4001,host2:4001 go run ./examples/multi_endpoint -lb=rr
-//
-// The -lb flag selects the load-balancing strategy: "random" (default) or
-// "rr" (round-robin). The example reports the observed dispatch counts per
-// endpoint by wrapping the Picker.
+// Writes to several GreptimeDB endpoints with client-side load balancing.
 package main
 
 import (
 	"context"
-	"flag"
-	"fmt"
 	"log"
-	"os"
-	"strings"
-	"sync"
-	"sync/atomic"
 	"time"
 
 	greptime "github.com/GreptimeTeam/greptimedb-ingester-go"
@@ -43,88 +28,23 @@ import (
 	"github.com/GreptimeTeam/greptimedb-ingester-go/table/types"
 )
 
-const (
-	database  = "public"
-	tableName = "multi_endpoint_demo"
-)
-
-// countingPicker wraps a Picker and tallies how many times each endpoint
-// gets selected, so the example can print a visible distribution at the end.
-type countingPicker struct {
-	inner  loadbalancer.Picker
-	mu     sync.Mutex
-	counts map[string]*atomic.Uint64
-}
-
-func newCountingPicker(inner loadbalancer.Picker) *countingPicker {
-	return &countingPicker{inner: inner, counts: map[string]*atomic.Uint64{}}
-}
-
-func (p *countingPicker) Pick(endpoints []string) string {
-	addr := p.inner.Pick(endpoints)
-	p.mu.Lock()
-	c, ok := p.counts[addr]
-	if !ok {
-		c = &atomic.Uint64{}
-		p.counts[addr] = c
-	}
-	p.mu.Unlock()
-	c.Add(1)
-	return addr
-}
-
-func (p *countingPicker) Report() string {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	parts := make([]string, 0, len(p.counts))
-	for addr, c := range p.counts {
-		parts = append(parts, fmt.Sprintf("%s=%d", addr, c.Load()))
-	}
-	return strings.Join(parts, " ")
-}
-
-func pickerFromFlag(name string) loadbalancer.Picker {
-	switch name {
-	case "rr", "round-robin", "roundrobin":
-		return loadbalancer.NewRoundRobin()
-	case "random", "":
-		return loadbalancer.NewRandom()
-	default:
-		log.Fatalf("unknown -lb value %q (want random|rr)", name)
-		return nil
-	}
-}
+const database = "public"
 
 func main() {
-	lbName := flag.String("lb", "random", "load-balancer: random | rr")
-	n := flag.Int("n", 20, "number of rows to write")
-	flag.Parse()
-
-	raw := os.Getenv("GREPTIMEDB_ENDPOINTS")
-	if raw == "" {
-		log.Fatal("set GREPTIMEDB_ENDPOINTS=host1:4001,host2:4001,...")
-	}
-	endpoints := strings.Split(raw, ",")
-	for i := range endpoints {
-		endpoints[i] = strings.TrimSpace(endpoints[i])
-	}
-
-	picker := newCountingPicker(pickerFromFlag(*lbName))
-
 	cfg := greptime.NewConfig().
 		WithDatabase(database).
-		WithEndpoints(endpoints...).
-		WithLoadBalancer(picker)
+		WithEndpoints("127.0.0.1:4001", "127.0.0.2:4001", "127.0.0.3:4001").
+		WithLoadBalancer(loadbalancer.NewRoundRobin()) // default is NewRandom()
 
 	client, err := greptime.NewClient(cfg)
 	if err != nil {
-		log.Fatalf("new client: %v", err)
+		log.Fatal(err)
 	}
-	defer func() { _ = client.Close() }()
+	defer client.Close()
 
-	tbl, err := table.New(tableName)
+	tbl, err := table.New("multi_endpoint_demo")
 	if err != nil {
-		log.Fatalf("new table: %v", err)
+		log.Fatal(err)
 	}
 	if err := tbl.AddTagColumn("host", types.STRING); err != nil {
 		log.Fatal(err)
@@ -139,16 +59,10 @@ func main() {
 		log.Fatal(err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	for i := 0; i < *n; i++ {
-		resp, err := client.Write(ctx, tbl)
-		if err != nil {
-			log.Fatalf("write %d: %v", i, err)
-		}
-		_ = resp
+	// Each Write picks one endpoint through the configured load balancer.
+	resp, err := client.Write(context.Background(), tbl)
+	if err != nil {
+		log.Fatal(err)
 	}
-
-	log.Printf("lb=%s total=%d dispatch: %s", *lbName, *n, picker.Report())
+	log.Printf("affected rows: %d", resp.GetAffectedRows().GetValue())
 }

--- a/examples/multi_endpoint/main.go
+++ b/examples/multi_endpoint/main.go
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2026 Greptime Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package main demonstrates writing to multiple GreptimeDB endpoints with
+// client-side load balancing.
+//
+// Usage:
+//
+//	GREPTIMEDB_ENDPOINTS=host1:4001,host2:4001 go run ./examples/multi_endpoint -lb=rr
+//
+// The -lb flag selects the load-balancing strategy: "random" (default) or
+// "rr" (round-robin). The example reports the observed dispatch counts per
+// endpoint by wrapping the Picker.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	greptime "github.com/GreptimeTeam/greptimedb-ingester-go"
+	"github.com/GreptimeTeam/greptimedb-ingester-go/loadbalancer"
+	"github.com/GreptimeTeam/greptimedb-ingester-go/table"
+	"github.com/GreptimeTeam/greptimedb-ingester-go/table/types"
+)
+
+const (
+	database  = "public"
+	tableName = "multi_endpoint_demo"
+)
+
+// countingPicker wraps a Picker and tallies how many times each endpoint
+// gets selected, so the example can print a visible distribution at the end.
+type countingPicker struct {
+	inner  loadbalancer.Picker
+	mu     sync.Mutex
+	counts map[string]*atomic.Uint64
+}
+
+func newCountingPicker(inner loadbalancer.Picker) *countingPicker {
+	return &countingPicker{inner: inner, counts: map[string]*atomic.Uint64{}}
+}
+
+func (p *countingPicker) Pick(endpoints []string) string {
+	addr := p.inner.Pick(endpoints)
+	p.mu.Lock()
+	c, ok := p.counts[addr]
+	if !ok {
+		c = &atomic.Uint64{}
+		p.counts[addr] = c
+	}
+	p.mu.Unlock()
+	c.Add(1)
+	return addr
+}
+
+func (p *countingPicker) Report() string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	parts := make([]string, 0, len(p.counts))
+	for addr, c := range p.counts {
+		parts = append(parts, fmt.Sprintf("%s=%d", addr, c.Load()))
+	}
+	return strings.Join(parts, " ")
+}
+
+func pickerFromFlag(name string) loadbalancer.Picker {
+	switch name {
+	case "rr", "round-robin", "roundrobin":
+		return loadbalancer.NewRoundRobin()
+	case "random", "":
+		return loadbalancer.NewRandom()
+	default:
+		log.Fatalf("unknown -lb value %q (want random|rr)", name)
+		return nil
+	}
+}
+
+func main() {
+	lbName := flag.String("lb", "random", "load-balancer: random | rr")
+	n := flag.Int("n", 20, "number of rows to write")
+	flag.Parse()
+
+	raw := os.Getenv("GREPTIMEDB_ENDPOINTS")
+	if raw == "" {
+		log.Fatal("set GREPTIMEDB_ENDPOINTS=host1:4001,host2:4001,...")
+	}
+	endpoints := strings.Split(raw, ",")
+	for i := range endpoints {
+		endpoints[i] = strings.TrimSpace(endpoints[i])
+	}
+
+	picker := newCountingPicker(pickerFromFlag(*lbName))
+
+	cfg := greptime.NewConfig().
+		WithDatabase(database).
+		WithEndpoints(endpoints...).
+		WithLoadBalancer(picker)
+
+	client, err := greptime.NewClient(cfg)
+	if err != nil {
+		log.Fatalf("new client: %v", err)
+	}
+	defer func() { _ = client.Close() }()
+
+	tbl, err := table.New(tableName)
+	if err != nil {
+		log.Fatalf("new table: %v", err)
+	}
+	if err := tbl.AddTagColumn("host", types.STRING); err != nil {
+		log.Fatal(err)
+	}
+	if err := tbl.AddFieldColumn("cpu", types.FLOAT64); err != nil {
+		log.Fatal(err)
+	}
+	if err := tbl.AddTimestampColumn("ts", types.TIMESTAMP_MILLISECOND); err != nil {
+		log.Fatal(err)
+	}
+	if err := tbl.AddRow("127.0.0.1", 1.0, time.Now()); err != nil {
+		log.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	for i := 0; i < *n; i++ {
+		resp, err := client.Write(ctx, tbl)
+		if err != nil {
+			log.Fatalf("write %d: %v", i, err)
+		}
+		_ = resp
+	}
+
+	log.Printf("lb=%s total=%d dispatch: %s", *lbName, *n, picker.Report())
+}

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2026 Greptime Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package pool manages a set of gRPC connections to GreptimeDB endpoints and
+// dispatches calls to one of them through a pluggable loadbalancer.Picker.
+package pool
+
+import (
+	"errors"
+	"fmt"
+
+	gpb "github.com/GreptimeTeam/greptime-proto/go/greptime/v1"
+	"google.golang.org/grpc"
+
+	"github.com/GreptimeTeam/greptimedb-ingester-go/bulk"
+	"github.com/GreptimeTeam/greptimedb-ingester-go/loadbalancer"
+)
+
+// Endpoint bundles a gRPC connection with the stubs created from it. All
+// stubs on one Endpoint share the same underlying *grpc.ClientConn.
+type Endpoint struct {
+	Addr   string
+	Conn   *grpc.ClientConn
+	DB     gpb.GreptimeDatabaseClient
+	Health gpb.HealthCheckClient
+	Bulk   *bulk.BulkClient
+}
+
+// Pool holds one Endpoint per address and dispatches Pick calls through the
+// configured Picker. Pool is safe for concurrent use.
+type Pool struct {
+	addrs     []string
+	endpoints map[string]*Endpoint
+	picker    loadbalancer.Picker
+}
+
+// New dials every address with the given dial options and returns a Pool.
+// grpc.NewClient is non-blocking: bad addresses surface as errors at the
+// first RPC, not here.
+func New(addrs []string, picker loadbalancer.Picker, dialOpts []grpc.DialOption) (*Pool, error) {
+	if len(addrs) == 0 {
+		return nil, errors.New("pool: at least one endpoint is required")
+	}
+	if picker == nil {
+		return nil, errors.New("pool: picker must not be nil")
+	}
+
+	p := &Pool{
+		addrs:     make([]string, 0, len(addrs)),
+		endpoints: make(map[string]*Endpoint, len(addrs)),
+		picker:    picker,
+	}
+
+	for _, addr := range addrs {
+		if _, dup := p.endpoints[addr]; dup {
+			// Duplicates would skew the picker; skip silently to keep the
+			// surface forgiving, but don't open two conns to the same host.
+			continue
+		}
+		conn, err := grpc.NewClient(addr, dialOpts...)
+		if err != nil {
+			// Undo partial state before returning.
+			_ = p.Close()
+			return nil, fmt.Errorf("pool: dial %s: %w", addr, err)
+		}
+		p.endpoints[addr] = &Endpoint{
+			Addr:   addr,
+			Conn:   conn,
+			DB:     gpb.NewGreptimeDatabaseClient(conn),
+			Health: gpb.NewHealthCheckClient(conn),
+			Bulk:   bulk.NewBulkClient(conn),
+		}
+		p.addrs = append(p.addrs, addr)
+	}
+	return p, nil
+}
+
+// Pick returns one Endpoint chosen by the configured picker. For a single
+// endpoint the picker is bypassed to avoid any per-call overhead.
+func (p *Pool) Pick() *Endpoint {
+	if len(p.addrs) == 1 {
+		return p.endpoints[p.addrs[0]]
+	}
+	return p.endpoints[p.picker.Pick(p.addrs)]
+}
+
+// Addrs returns the list of endpoint addresses. The returned slice must not
+// be mutated.
+func (p *Pool) Addrs() []string {
+	return p.addrs
+}
+
+// Close closes every underlying gRPC connection. Errors from individual
+// closes are joined.
+func (p *Pool) Close() error {
+	var errs []error
+	for _, ep := range p.endpoints {
+		if ep.Conn != nil {
+			if err := ep.Conn.Close(); err != nil {
+				errs = append(errs, fmt.Errorf("close %s: %w", ep.Addr, err))
+			}
+		}
+	}
+	return errors.Join(errs...)
+}

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2026 Greptime Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pool
+
+import (
+	"context"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	gpb "github.com/GreptimeTeam/greptime-proto/go/greptime/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/GreptimeTeam/greptimedb-ingester-go/loadbalancer"
+)
+
+// fakeHealthServer counts HealthCheck invocations so tests can assert
+// which endpoint received a given call.
+type fakeHealthServer struct {
+	gpb.UnimplementedHealthCheckServer
+	calls atomic.Uint64
+}
+
+func (s *fakeHealthServer) HealthCheck(_ context.Context, _ *gpb.HealthCheckRequest) (*gpb.HealthCheckResponse, error) {
+	s.calls.Add(1)
+	return &gpb.HealthCheckResponse{}, nil
+}
+
+type fakeEndpoint struct {
+	addr   string
+	server *grpc.Server
+	health *fakeHealthServer
+}
+
+func startFakeEndpoint(t *testing.T) *fakeEndpoint {
+	t.Helper()
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	health := &fakeHealthServer{}
+	srv := grpc.NewServer()
+	gpb.RegisterHealthCheckServer(srv, health)
+
+	go func() { _ = srv.Serve(lis) }()
+
+	return &fakeEndpoint{
+		addr:   lis.Addr().String(),
+		server: srv,
+		health: health,
+	}
+}
+
+func (e *fakeEndpoint) stop() { e.server.Stop() }
+
+func dialOpts() []grpc.DialOption {
+	return []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}
+}
+
+func TestPoolRoundRobinDispatch(t *testing.T) {
+	const n = 3
+	eps := make([]*fakeEndpoint, n)
+	addrs := make([]string, n)
+	for i := 0; i < n; i++ {
+		eps[i] = startFakeEndpoint(t)
+		addrs[i] = eps[i].addr
+	}
+	defer func() {
+		for _, e := range eps {
+			e.stop()
+		}
+	}()
+
+	p, err := New(addrs, loadbalancer.NewRoundRobin(), dialOpts())
+	require.NoError(t, err)
+	defer func() { _ = p.Close() }()
+
+	const iters = 30
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	for i := 0; i < iters; i++ {
+		_, err := p.Pick().Health.HealthCheck(ctx, &gpb.HealthCheckRequest{})
+		require.NoError(t, err)
+	}
+
+	for i, e := range eps {
+		assert.Equal(t, uint64(iters/n), e.health.calls.Load(),
+			"endpoint %d (%s) call count", i, e.addr)
+	}
+}
+
+func TestPoolRandomHitsAllEndpoints(t *testing.T) {
+	const n = 3
+	eps := make([]*fakeEndpoint, n)
+	addrs := make([]string, n)
+	for i := 0; i < n; i++ {
+		eps[i] = startFakeEndpoint(t)
+		addrs[i] = eps[i].addr
+	}
+	defer func() {
+		for _, e := range eps {
+			e.stop()
+		}
+	}()
+
+	p, err := New(addrs, loadbalancer.NewRandom(), dialOpts())
+	require.NoError(t, err)
+	defer func() { _ = p.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	for i := 0; i < 300; i++ {
+		_, err := p.Pick().Health.HealthCheck(ctx, &gpb.HealthCheckRequest{})
+		require.NoError(t, err)
+	}
+	for i, e := range eps {
+		assert.Greater(t, e.health.calls.Load(), uint64(0),
+			"endpoint %d (%s) should have received at least one call", i, e.addr)
+	}
+}
+
+func TestPoolSingleEndpointSkipsPicker(t *testing.T) {
+	ep := startFakeEndpoint(t)
+	defer ep.stop()
+
+	// Use a picker that would explode if called, proving the fast path bypass.
+	p, err := New([]string{ep.addr}, panicPicker{}, dialOpts())
+	require.NoError(t, err)
+	defer func() { _ = p.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_, err = p.Pick().Health.HealthCheck(ctx, &gpb.HealthCheckRequest{})
+	require.NoError(t, err)
+}
+
+func TestPoolDuplicateAddrsDeduplicated(t *testing.T) {
+	ep := startFakeEndpoint(t)
+	defer ep.stop()
+
+	p, err := New([]string{ep.addr, ep.addr, ep.addr}, loadbalancer.NewRoundRobin(), dialOpts())
+	require.NoError(t, err)
+	defer func() { _ = p.Close() }()
+
+	assert.Equal(t, []string{ep.addr}, p.Addrs())
+}
+
+func TestPoolEmptyAddrsError(t *testing.T) {
+	_, err := New(nil, loadbalancer.NewRandom(), dialOpts())
+	assert.Error(t, err)
+}
+
+func TestPoolNilPickerError(t *testing.T) {
+	_, err := New([]string{"127.0.0.1:1"}, nil, dialOpts())
+	assert.Error(t, err)
+}
+
+func TestPoolCloseIsIdempotent(t *testing.T) {
+	ep := startFakeEndpoint(t)
+	defer ep.stop()
+
+	p, err := New([]string{ep.addr}, loadbalancer.NewRandom(), dialOpts())
+	require.NoError(t, err)
+
+	assert.NoError(t, p.Close())
+	// Second Close on already-closed gRPC conns should be non-fatal; gRPC
+	// returns an error but the pool joins and returns it. We only assert it
+	// does not panic.
+	_ = p.Close()
+}
+
+type panicPicker struct{}
+
+func (panicPicker) Pick(_ []string) string { panic("picker should not be called for single endpoint") }

--- a/loadbalancer/loadbalancer.go
+++ b/loadbalancer/loadbalancer.go
@@ -24,7 +24,9 @@ import (
 )
 
 // Picker selects one endpoint from the given slice per call.
-// Implementations must be safe for concurrent use.
+// Implementations must be safe for concurrent use. Callers must pass a
+// non-empty slice; behavior on an empty slice is undefined and the
+// built-in pickers will panic.
 type Picker interface {
 	Pick(endpoints []string) string
 }

--- a/loadbalancer/loadbalancer.go
+++ b/loadbalancer/loadbalancer.go
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 Greptime Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package loadbalancer provides pluggable strategies for distributing
+// requests across multiple GreptimeDB endpoints.
+package loadbalancer
+
+import (
+	"math/rand/v2"
+	"sync/atomic"
+)
+
+// Picker selects one endpoint from the given slice per call.
+// Implementations must be safe for concurrent use.
+type Picker interface {
+	Pick(endpoints []string) string
+}
+
+type randomPicker struct{}
+
+// NewRandom returns a stateless Picker that uniformly picks an endpoint at
+// random on every call. This is the default strategy.
+func NewRandom() Picker {
+	return randomPicker{}
+}
+
+func (randomPicker) Pick(endpoints []string) string {
+	return endpoints[rand.IntN(len(endpoints))]
+}
+
+type roundRobinPicker struct {
+	counter atomic.Uint64
+}
+
+// NewRoundRobin returns a Picker that rotates through endpoints in order.
+// Safe for concurrent use via an atomic counter.
+func NewRoundRobin() Picker {
+	return &roundRobinPicker{}
+}
+
+func (p *roundRobinPicker) Pick(endpoints []string) string {
+	n := p.counter.Add(1) - 1
+	return endpoints[n%uint64(len(endpoints))]
+}

--- a/loadbalancer/loadbalancer_test.go
+++ b/loadbalancer/loadbalancer_test.go
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2026 Greptime Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package loadbalancer
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRandomPickerCoversAllEndpoints(t *testing.T) {
+	picker := NewRandom()
+	endpoints := []string{"a:1", "b:1", "c:1"}
+	seen := map[string]int{}
+	const iters = 3000
+	for i := 0; i < iters; i++ {
+		seen[picker.Pick(endpoints)]++
+	}
+
+	assert.Len(t, seen, len(endpoints), "all endpoints should be picked at least once")
+	for _, addr := range endpoints {
+		// Expected ~iters/len; tolerate wide skew so the test is not flaky.
+		assert.Greater(t, seen[addr], iters/10,
+			"endpoint %s picked %d times, expected significant share", addr, seen[addr])
+	}
+}
+
+func TestRoundRobinPickerRotates(t *testing.T) {
+	picker := NewRoundRobin()
+	endpoints := []string{"a:1", "b:1", "c:1"}
+	want := []string{"a:1", "b:1", "c:1", "a:1", "b:1", "c:1", "a:1"}
+	for i, exp := range want {
+		got := picker.Pick(endpoints)
+		assert.Equal(t, exp, got, "iteration %d", i)
+	}
+}
+
+func TestRoundRobinPickerConcurrentSafe(t *testing.T) {
+	picker := NewRoundRobin()
+	endpoints := []string{"a:1", "b:1", "c:1", "d:1"}
+
+	const goroutines = 16
+	const perG = 500
+	counts := make(map[string]*atomic.Uint64, len(endpoints))
+	for _, ep := range endpoints {
+		counts[ep] = &atomic.Uint64{}
+	}
+
+	var wg sync.WaitGroup
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < perG; i++ {
+				counts[picker.Pick(endpoints)].Add(1)
+			}
+		}()
+	}
+	wg.Wait()
+
+	total := uint64(0)
+	for _, c := range counts {
+		total += c.Load()
+	}
+	assert.Equal(t, uint64(goroutines*perG), total)
+
+	// Perfect rotation distributes total/len to each endpoint. The atomic
+	// counter guarantees exact fairness regardless of goroutine interleaving.
+	expected := total / uint64(len(endpoints))
+	for ep, c := range counts {
+		assert.Equal(t, expected, c.Load(),
+			"endpoint %s count %d, expected %d", ep, c.Load(), expected)
+	}
+}

--- a/table/types/arrow.go
+++ b/table/types/arrow.go
@@ -26,6 +26,17 @@ import (
 	"github.com/apache/arrow/go/v17/arrow/memory"
 )
 
+// Timezone-less timestamp types. arrow-go's FixedWidthTypes.Timestamp_* default
+// to TimeZone="UTC", but GreptimeDB's server-side schema expects Timestamp(unit)
+// without a timezone for bulk (Arrow Flight) writes, and rejects the record
+// batch with "expected Timestamp(ms) but found Timestamp(ms, \"UTC\")".
+var (
+	timestampTypeS  = &arrow.TimestampType{Unit: arrow.Second}
+	timestampTypeMs = &arrow.TimestampType{Unit: arrow.Millisecond}
+	timestampTypeUs = &arrow.TimestampType{Unit: arrow.Microsecond}
+	timestampTypeNs = &arrow.TimestampType{Unit: arrow.Nanosecond}
+)
+
 // ArrowConverter handles conversion between GreptimeDB and Arrow formats
 type ArrowConverter struct{}
 
@@ -131,14 +142,14 @@ func (c *ArrowConverter) convertToArrowType(dt gpbv1.ColumnDataType) (arrow.Data
 	case gpbv1.ColumnDataType_BINARY:
 		return arrow.BinaryTypes.Binary, nil
 	case gpbv1.ColumnDataType_TIMESTAMP_MILLISECOND:
-		return arrow.FixedWidthTypes.Timestamp_ms, nil
+		return timestampTypeMs, nil
 	case gpbv1.ColumnDataType_TIMESTAMP_MICROSECOND, gpbv1.ColumnDataType_DATETIME:
 		// DATETIME is a deprecated alias for TIMESTAMP_MICROSECOND (greptimedb PR #5506).
-		return arrow.FixedWidthTypes.Timestamp_us, nil
+		return timestampTypeUs, nil
 	case gpbv1.ColumnDataType_TIMESTAMP_NANOSECOND:
-		return arrow.FixedWidthTypes.Timestamp_ns, nil
+		return timestampTypeNs, nil
 	case gpbv1.ColumnDataType_TIMESTAMP_SECOND:
-		return arrow.FixedWidthTypes.Timestamp_s, nil
+		return timestampTypeS, nil
 	case gpbv1.ColumnDataType_DATE:
 		return arrow.FixedWidthTypes.Date32, nil
 	case gpbv1.ColumnDataType_TIME_SECOND:

--- a/table/types/arrow_test.go
+++ b/table/types/arrow_test.go
@@ -37,7 +37,7 @@ func TestConvertToArrowType_DatetimeIsMicrosecond(t *testing.T) {
 
 	dtType, err := c.convertToArrowType(gpbv1.ColumnDataType_DATETIME)
 	require.NoError(t, err)
-	assert.Equal(t, arrow.FixedWidthTypes.Timestamp_us, dtType)
+	assert.Equal(t, timestampTypeUs, dtType)
 
 	tsType, err := c.convertToArrowType(gpbv1.ColumnDataType_TIMESTAMP_MICROSECOND)
 	require.NoError(t, err)
@@ -76,7 +76,7 @@ func TestToArrow_DatetimeColumn(t *testing.T) {
 	require.Equal(t, int64(1), record.NumCols())
 
 	field := record.Schema().Field(0)
-	assert.Equal(t, arrow.FixedWidthTypes.Timestamp_us, field.Type)
+	assert.Equal(t, timestampTypeUs, field.Type)
 
 	col, ok := record.Column(0).(*array.Timestamp)
 	require.True(t, ok, "column must be *array.Timestamp")


### PR DESCRIPTION
## What's changed and what's your intention?

1. Supports multi endpoints:

```go
cfg := greptime.NewConfig().
    WithDatabase("<database>").
    WithEndpoints("host1:4001", "host2:4001", "host3:4001").
    WithLoadBalancer(loadbalancer.NewRoundRobin()) // default is NewRandom()
```

2. Remove timezone info in timestamp types.

Close #6 

## Checklist

- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)