### PR TITLE
feat: add multi-endpoint failover

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,11 +71,15 @@ becomes unreachable, instead of surfacing every transient transport error to
 the caller.
 
 **Retry across endpoints.** Unary calls retry on retryable transport failures
-(`Unavailable`, `DeadlineExceeded`, `ResourceExhausted`, `Aborted`, `Unknown`),
-re-picking a *different* endpoint each attempt — a single dead endpoint cannot
-burn the whole retry budget. Server business errors (e.g. `InvalidArgument`,
-`TableNotFound`) are never retried. The policy is configurable; the default is
-three attempts with exponential backoff and full jitter:
+(`Unavailable`, `ResourceExhausted`, `Aborted`, `Unknown`), re-picking a
+*different* endpoint each attempt — a single dead endpoint cannot burn the whole
+retry budget. Server business errors (e.g. `InvalidArgument`, `TableNotFound`)
+are never retried. Neither is `DeadlineExceeded` or context cancellation: the
+client forwards the caller's context to each attempt, so an elapsed deadline
+means the caller ran out of time — retrying would reuse the same expired
+context, and a healthy endpoint is not penalized for it. The policy is
+configurable; the default is three attempts with exponential backoff and full
+jitter:
 
 ```go
 cfg.WithRetry(greptime.RetryPolicy{

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ cfg := greptime.NewConfig().
 ```
 
 See [`examples/multi_endpoint`](examples/multi_endpoint/main.go) for a runnable
-demo that reports per-endpoint dispatch counts.
+configuration example with health-aware failover.
 
 ##### Failover
 

--- a/README.md
+++ b/README.md
@@ -70,14 +70,23 @@ For an HA deployment, the client can fail over to another endpoint when one
 becomes unreachable, instead of surfacing every transient transport error to
 the caller.
 
-**Retry across endpoints.** Unary calls retry on retryable transport failures
-(`Unavailable`, `ResourceExhausted`, `Aborted`, `Unknown`), re-picking a
-*different* endpoint each attempt — a single dead endpoint cannot burn the whole
-retry budget. Server business errors (e.g. `InvalidArgument`, `TableNotFound`)
-are never retried. Neither is `DeadlineExceeded` or context cancellation: the
-client forwards the caller's context to each attempt, so an elapsed deadline
-means the caller ran out of time — retrying would reuse the same expired
-context, and a healthy endpoint is not penalized for it. The policy is
+**Retry across endpoints.** Unary calls retry on retryable failures, re-picking
+a *different* endpoint each attempt — a single dead endpoint cannot burn the
+whole retry budget. Retryable means:
+
+- transport failures: `Unavailable`, `ResourceExhausted`, `Aborted`, `Unknown`;
+- transient GreptimeDB server errors, classified by the precise status code
+  carried in the `x-greptime-err-code` trailer: `RegionNotReady`, `RegionBusy`,
+  `TableUnavailable`, `StorageUnavailable`, `RuntimeResourcesExhausted`.
+
+The precise status code matters because the server collapses several codes onto
+one gRPC code (e.g. `RegionBusy` and `RateLimited` both surface as
+`ResourceExhausted`, but only `RegionBusy` is worth retrying). Other server
+errors (`InvalidArguments`, `TableNotFound`, auth failures, `Internal`) are
+never retried, and a server error never ejects the endpoint from a health-aware
+selector — it answered, so it is alive. Neither `DeadlineExceeded` nor context
+cancellation is retried: the client forwards the caller's context to each
+attempt, so an elapsed deadline means the caller ran out of time. The policy is
 configurable; the default is three attempts with exponential backoff and full
 jitter:
 

--- a/README.md
+++ b/README.md
@@ -48,11 +48,8 @@ cfg.WithKeepalive(time.Second*30, time.Second*5) // keepalive isn't enabled by d
 ##### Multiple endpoints
 
 Configure several GreptimeDB endpoints to spread writes across an HA cluster.
-Unary calls (`Write`, `Delete`, `HealthCheck`, `BulkWrite`) pick an endpoint
-per call through the configured picker. A streaming session started by
-`StreamWrite` / `StreamDelete` binds to one endpoint until `CloseStream`; if
-that endpoint fails mid-stream the Send returns the error and the next
-`StreamWrite` picks a fresh endpoint. Auth, TLS, keepalive and telemetry are
+Unary calls (`Write`, `Delete`, `HealthCheck`) select an endpoint per call
+through the configured load balancer. Auth, TLS, keepalive and telemetry are
 shared across all endpoints.
 
 ```go
@@ -66,6 +63,53 @@ cfg := greptime.NewConfig().
 
 See [`examples/multi_endpoint`](examples/multi_endpoint/main.go) for a runnable
 demo that reports per-endpoint dispatch counts.
+
+##### Failover
+
+For an HA deployment, the client can fail over to another endpoint when one
+becomes unreachable, instead of surfacing every transient transport error to
+the caller.
+
+**Retry across endpoints.** Unary calls retry on retryable transport failures
+(`Unavailable`, `DeadlineExceeded`, `ResourceExhausted`, `Aborted`, `Unknown`),
+re-picking a *different* endpoint each attempt — a single dead endpoint cannot
+burn the whole retry budget. Server business errors (e.g. `InvalidArgument`,
+`TableNotFound`) are never retried. The policy is configurable; the default is
+three attempts with exponential backoff and full jitter:
+
+```go
+cfg.WithRetry(greptime.RetryPolicy{
+    MaxAttempts:       3,
+    InitialBackoff:    100 * time.Millisecond,
+    MaxBackoff:        5 * time.Second,
+    BackoffMultiplier: 2,
+    Jitter:            true,
+})
+```
+
+**Health-aware ejection.** With `loadbalancer.NewOutlierDetector`, an endpoint
+that fails repeatedly (transport-level only) is temporarily ejected from
+selection and re-admitted after a back-off window (which doubles on repeated
+ejection) or as soon as it serves a successful call. A server business error
+keeps the endpoint in rotation — it proves the endpoint is alive and routing
+correctly.
+
+```go
+cfg.WithLoadBalancer(loadbalancer.NewOutlierDetector(loadbalancer.OutlierDetectorOptions{
+    Base:                loadbalancer.NewRoundRobin(), // selection among healthy peers; default NewRandom
+    ConsecutiveFailures: 5,                            // failures in a row before ejection
+    BaseEjection:        30 * time.Second,             // first ejection window
+    MaxEjection:         300 * time.Second,            // ceiling for a single ejection
+}))
+```
+
+**Boundaries.** `BulkWrite` selects one healthy endpoint and reports its health,
+but is not auto-retried: a mid-stream bulk failure may have already landed rows,
+so a transparent retry could duplicate them — rebuild by calling `BulkWrite`
+again. A streaming session (`StreamWrite` / `StreamDelete`) binds to one
+endpoint until `CloseStream`; if it fails mid-stream the `Send` returns the
+error and the next `StreamWrite` picks a fresh endpoint. Both feed the load
+balancer's health state so a failed endpoint is avoided on the next pick.
 
 ### Client
 

--- a/client.go
+++ b/client.go
@@ -38,14 +38,29 @@ import (
 // use by multiple goroutines; one instance per application is typical.
 //
 // When configured with multiple endpoints via Config.WithEndpoints, unary
-// calls (Write, Delete, HealthCheck, BulkWrite) pick an endpoint per call
-// through the configured loadbalancer.Picker. A streaming session opened by
-// StreamWrite/StreamDelete binds to a single endpoint until CloseStream;
-// if that endpoint fails mid-stream, the Send returns the underlying error
-// and the next StreamWrite call picks a fresh endpoint to open a new stream.
+// calls (Write, Delete, HealthCheck) select an endpoint per call through the
+// configured loadbalancer and retry retryable transport failures on another
+// healthy endpoint, per the RetryPolicy (see Config.WithRetry). With a
+// health-aware load balancer (loadbalancer.NewOutlierDetector) endpoints that
+// fail repeatedly are temporarily ejected from selection and re-admitted after
+// a back-off window or a fresh success.
+//
+// BulkWrite selects one healthy endpoint and is not auto-retried (a mid-stream
+// bulk failure may have already landed rows). A streaming session opened by
+// StreamWrite/StreamDelete binds to a single endpoint until CloseStream; if
+// that endpoint fails mid-stream the Send returns the underlying error and the
+// next StreamWrite picks a fresh endpoint to open a new stream. Both feed the
+// load balancer's health state so a failed endpoint is avoided on the next pick.
 type Client struct {
 	cfg  *Config
 	pool *pool.Pool
+
+	// selector turns the endpoint list into one address per call, honoring an
+	// exclude set during a retry sequence. health is the same instance when the
+	// configured picker reports endpoint health, nil otherwise.
+	selector loadbalancer.Selector
+	health   loadbalancer.HealthReporter
+	retry    RetryPolicy
 
 	// closed guards Close against repeated invocations. The pool pointer
 	// itself is intentionally left stable after Close so that any RPC still
@@ -55,6 +70,9 @@ type Client struct {
 
 	streamMu sync.Mutex
 	stream   gpb.GreptimeDatabase_HandleRequestsClient
+	// streamPeer is the endpoint the cached stream is bound to, used to report
+	// the stream's terminal health outcome.
+	streamPeer string
 }
 
 // NewClient creates the greptimedb client responsible for writing data into
@@ -76,23 +94,38 @@ func NewClient(cfg *Config) (*Client, error) {
 		picker = loadbalancer.NewRandom()
 	}
 
-	p, err := pool.New(addrs, picker, cfg.build())
+	p, err := pool.New(addrs, cfg.build())
 	if err != nil {
 		return nil, err
 	}
 
-	return &Client{cfg: cfg, pool: p}, nil
+	c := &Client{
+		cfg:      cfg,
+		pool:     p,
+		selector: loadbalancer.AsSelector(picker),
+		retry:    cfg.retryPolicy(),
+	}
+	// A health-aware picker (e.g. OutlierDetector) drives ejection; stateless
+	// pickers leave health nil and only the per-sequence exclude steering applies.
+	if hr, ok := picker.(loadbalancer.HealthReporter); ok {
+		c.health = hr
+	}
+	return c, nil
 }
 
-// submit builds a request and dispatches it to a picked endpoint. picking
-// fresh per call keeps the path retry-friendly once a retry layer lands.
+// submit builds a request once and dispatches it across endpoints with failover
+// retry. Request building happens before the loop so a client-side encode error
+// fails immediately without consuming the retry budget or touching endpoint health.
 func (c *Client) submit(ctx context.Context, operation types.Operation, tables ...*table.Table) (*gpb.GreptimeResponse, error) {
 	header_ := header.New(c.cfg.Database).WithAuth(c.cfg.Username, c.cfg.Password)
 	request_, err := request.New(header_, operation, tables...).Build()
 	if err != nil {
 		return nil, err
 	}
-	return c.pool.Pick().DB.Handle(ctx, request_)
+	return runWithFailover(ctx, c.pool.Addrs(), c.selector, c.health, c.retry,
+		func(peer string) (*gpb.GreptimeResponse, error) {
+			return c.pool.Get(peer).DB.Handle(ctx, request_)
+		})
 }
 
 // Write is to write the data into GreptimeDB via explicit schema.
@@ -203,11 +236,14 @@ func (c *Client) streamSubmit(ctx context.Context, operation types.Operation, ta
 	defer c.streamMu.Unlock()
 
 	if c.stream == nil {
-		s, err := c.pool.Pick().DB.HandleRequests(ctx)
+		peer := c.selector.Select(c.pool.Addrs(), nil)
+		s, err := c.pool.Get(peer).DB.HandleRequests(ctx)
 		if err != nil {
+			reportOutcome(c.health, peer, err)
 			return err
 		}
 		c.stream = s
+		c.streamPeer = peer
 	}
 
 	header_ := header.New(c.cfg.Database).WithAuth(c.cfg.Username, c.cfg.Password)
@@ -216,8 +252,11 @@ func (c *Client) streamSubmit(ctx context.Context, operation types.Operation, ta
 		return err
 	}
 	if err := c.stream.Send(request_); err != nil {
-		// Clear the broken stream so the next call rebuilds on a fresh pick.
+		// Clear the broken stream so the next call rebuilds on a fresh pick,
+		// and let a health-aware selector steer away from the failed endpoint.
+		reportOutcome(c.health, c.streamPeer, err)
 		c.stream = nil
+		c.streamPeer = ""
 		return err
 	}
 	return nil
@@ -327,7 +366,10 @@ func (c *Client) CloseStream(_ context.Context) (*gpb.AffectedRows, error) {
 	}
 
 	resp, err := c.stream.CloseAndRecv()
+	peer := c.streamPeer
 	c.stream = nil
+	c.streamPeer = ""
+	reportOutcome(c.health, peer, err)
 	if err != nil {
 		return nil, err
 	}
@@ -336,11 +378,16 @@ func (c *Client) CloseStream(_ context.Context) (*gpb.AffectedRows, error) {
 }
 
 // HealthCheck will check GreptimeDB health status. With multiple endpoints
-// configured, HealthCheck probes whichever endpoint the picker returns for
-// this call, not every endpoint.
+// configured, HealthCheck probes whichever endpoint the selector returns for
+// this call (not every endpoint) and, being idempotent, retries on another
+// healthy endpoint on a retryable transport failure. A success re-admits a
+// previously ejected endpoint in a health-aware selector.
 func (c *Client) HealthCheck(ctx context.Context) (*gpb.HealthCheckResponse, error) {
 	req := &gpb.HealthCheckRequest{}
-	return c.pool.Pick().Health.HealthCheck(ctx, req)
+	return runWithFailover(ctx, c.pool.Addrs(), c.selector, c.health, c.retry,
+		func(peer string) (*gpb.HealthCheckResponse, error) {
+			return c.pool.Get(peer).Health.HealthCheck(ctx, req)
+		})
 }
 
 // Close terminates all underlying gRPC connections. Any active stream is
@@ -363,6 +410,15 @@ func (c *Client) Close() error {
 // BulkWrite performs a high-efficiency bulk data write operation to GreptimeDB using Apache Arrow format.
 // It sends the entire table data in a single batch, which is more efficient for large datasets compared to row-by-row writes.
 // The table must have columns and rows properly defined before calling this method.
+//
+// BulkWrite selects one healthy endpoint via the configured load balancer and
+// reports the outcome to its health state, but is not auto-retried: a bulk
+// failure may have already landed part of the batch, so transparent retry could
+// duplicate rows. On failure, rebuild by calling BulkWrite again — a
+// health-aware selector then steers away from the endpoint that just failed.
 func (c *Client) BulkWrite(ctx context.Context, table *table.Table) (*gpb.GreptimeResponse, error) {
-	return c.pool.Pick().Bulk.BulkWrite(ctx, table)
+	peer := c.selector.Select(c.pool.Addrs(), nil)
+	resp, err := c.pool.Get(peer).Bulk.BulkWrite(ctx, table)
+	reportOutcome(c.health, peer, err)
+	return resp, err
 }

--- a/client.go
+++ b/client.go
@@ -24,6 +24,8 @@ import (
 	"sync/atomic"
 
 	gpb "github.com/GreptimeTeam/greptime-proto/go/greptime/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 
 	"github.com/GreptimeTeam/greptimedb-ingester-go/internal/pool"
 	"github.com/GreptimeTeam/greptimedb-ingester-go/loadbalancer"
@@ -124,7 +126,11 @@ func (c *Client) submit(ctx context.Context, operation types.Operation, tables .
 	}
 	return runWithFailover(ctx, c.pool.Addrs(), c.selector, c.health, c.retry,
 		func(peer string) (*gpb.GreptimeResponse, error) {
-			return c.pool.Get(peer).DB.Handle(ctx, request_)
+			// Capture the response trailer so a GreptimeDB business error can be
+			// classified by its precise status code, not just the lossy gRPC code.
+			var trailer metadata.MD
+			resp, err := c.pool.Get(peer).DB.Handle(ctx, request_, grpc.Trailer(&trailer))
+			return resp, withServerStatus(err, trailer)
 		})
 }
 

--- a/client.go
+++ b/client.go
@@ -41,11 +41,12 @@ import (
 //
 // When configured with multiple endpoints via Config.WithEndpoints, unary
 // calls (Write, Delete, HealthCheck) select an endpoint per call through the
-// configured loadbalancer and retry retryable transport failures on another
-// healthy endpoint, per the RetryPolicy (see Config.WithRetry). With a
-// health-aware load balancer (loadbalancer.NewOutlierDetector) endpoints that
-// fail repeatedly are temporarily ejected from selection and re-admitted after
-// a back-off window or a fresh success.
+// configured loadbalancer and retry retryable transport failures or transient
+// GreptimeDB server errors on another healthy endpoint, per the RetryPolicy
+// (see Config.WithRetry). With a health-aware load balancer
+// (loadbalancer.NewOutlierDetector) endpoints that fail repeatedly are
+// temporarily ejected from selection and re-admitted after a back-off window or
+// a fresh success.
 //
 // BulkWrite selects one healthy endpoint and is not auto-retried (a mid-stream
 // bulk failure may have already landed rows). A streaming session opened by

--- a/client_failover_test.go
+++ b/client_failover_test.go
@@ -19,6 +19,7 @@ package greptime
 import (
 	"context"
 	"net"
+	"strconv"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -28,6 +29,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
 	"github.com/GreptimeTeam/greptimedb-ingester-go/loadbalancer"
@@ -43,10 +45,19 @@ type fakeDBServer struct {
 	server    *grpc.Server
 	calls     atomic.Uint64
 	available atomic.Bool
+	// bizCode, when nonzero, makes Handle return a business error carrying this
+	// GreptimeDB status code in the x-greptime-err-code trailer.
+	bizCode atomic.Uint32
 }
 
-func (s *fakeDBServer) Handle(_ context.Context, _ *gpb.GreptimeRequest) (*gpb.GreptimeResponse, error) {
+func (s *fakeDBServer) Handle(ctx context.Context, _ *gpb.GreptimeRequest) (*gpb.GreptimeResponse, error) {
 	s.calls.Add(1)
+	// Simulate a GreptimeDB business error: a gRPC status plus the precise
+	// status code in the x-greptime-err-code trailer, exactly as the server does.
+	if code := s.bizCode.Load(); code != 0 {
+		_ = grpc.SetTrailer(ctx, metadata.Pairs("x-greptime-err-code", strconv.FormatUint(uint64(code), 10)))
+		return nil, status.Error(codes.ResourceExhausted, "business error")
+	}
 	if !s.available.Load() {
 		return nil, status.Error(codes.Unavailable, "endpoint down")
 	}
@@ -158,4 +169,68 @@ func TestClientWriteEjectsAndRecoversEndpoint(t *testing.T) {
 		got[detector.Select([]string{down.addr, up.addr}, nil)] = struct{}{}
 	}
 	assert.Contains(t, got, down.addr, "recovered endpoint should re-enter rotation")
+}
+
+// A non-retryable business error (RateLimited maps to ResourceExhausted but is
+// not retryable) must fail fast without burning retries, and must not eject the
+// endpoint — it answered correctly.
+func TestClientWriteDoesNotRetryNonRetryableServerError(t *testing.T) {
+	s := startFakeDB(t, true)
+	s.bizCode.Store(6001) // RateLimited
+
+	detector := loadbalancer.NewOutlierDetector(loadbalancer.OutlierDetectorOptions{ConsecutiveFailures: 1})
+	cfg := NewConfig().
+		WithDatabase("public").
+		WithEndpoints(s.addr).
+		WithLoadBalancer(detector).
+		WithRetry(RetryPolicy{MaxAttempts: 3, InitialBackoff: time.Millisecond, MaxBackoff: 2 * time.Millisecond, BackoffMultiplier: 2})
+	client, err := NewClient(cfg)
+	require.NoError(t, err)
+	defer func() { _ = client.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err = client.Write(ctx, failoverTestTable(t))
+	require.Error(t, err)
+	assert.Equal(t, codes.ResourceExhausted, status.Code(err), "underlying gRPC status preserved")
+	assert.Equal(t, uint64(1), s.calls.Load(), "non-retryable server error must not retry")
+	// The endpoint answered, so it stays healthy and selectable.
+	assert.Equal(t, s.addr, detector.Select([]string{s.addr}, nil))
+}
+
+// A retryable business error (RegionBusy) is retried on another endpoint, and
+// the busy endpoint is not ejected (it is alive, just transiently busy).
+func TestClientWriteRetriesRetryableServerError(t *testing.T) {
+	busy := startFakeDB(t, true)
+	busy.bizCode.Store(4009) // RegionBusy → retryable
+	up := startFakeDB(t, true)
+
+	detector := loadbalancer.NewOutlierDetector(loadbalancer.OutlierDetectorOptions{
+		Base:                loadbalancer.NewRoundRobin(),
+		ConsecutiveFailures: 1,
+	})
+	cfg := NewConfig().
+		WithDatabase("public").
+		WithEndpoints(busy.addr, up.addr).
+		WithLoadBalancer(detector).
+		WithRetry(RetryPolicy{MaxAttempts: 3, InitialBackoff: time.Millisecond, MaxBackoff: 2 * time.Millisecond, BackoffMultiplier: 2})
+	client, err := NewClient(cfg)
+	require.NoError(t, err)
+	defer func() { _ = client.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	for i := 0; i < 6; i++ {
+		resp, err := client.Write(ctx, failoverTestTable(t))
+		require.NoError(t, err, "write %d should retry past the RegionBusy endpoint", i)
+		assert.Equal(t, uint32(1), resp.GetAffectedRows().GetValue())
+	}
+	// Busy endpoint must remain selectable — a business error never ejects it.
+	picks := map[string]struct{}{}
+	for i := 0; i < 50; i++ {
+		picks[detector.Select([]string{busy.addr, up.addr}, nil)] = struct{}{}
+	}
+	assert.Contains(t, picks, busy.addr, "RegionBusy endpoint must not be ejected")
 }

--- a/client_failover_test.go
+++ b/client_failover_test.go
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2026 Greptime Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package greptime
+
+import (
+	"context"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	gpb "github.com/GreptimeTeam/greptime-proto/go/greptime/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/GreptimeTeam/greptimedb-ingester-go/loadbalancer"
+	"github.com/GreptimeTeam/greptimedb-ingester-go/table"
+	"github.com/GreptimeTeam/greptimedb-ingester-go/table/types"
+)
+
+// fakeDBServer is a minimal GreptimeDatabase backend whose Handle behavior is
+// switchable, so tests can simulate a healthy endpoint and an unavailable one.
+type fakeDBServer struct {
+	gpb.UnimplementedGreptimeDatabaseServer
+	addr      string
+	server    *grpc.Server
+	calls     atomic.Uint64
+	available atomic.Bool
+}
+
+func (s *fakeDBServer) Handle(_ context.Context, _ *gpb.GreptimeRequest) (*gpb.GreptimeResponse, error) {
+	s.calls.Add(1)
+	if !s.available.Load() {
+		return nil, status.Error(codes.Unavailable, "endpoint down")
+	}
+	return &gpb.GreptimeResponse{
+		Response: &gpb.GreptimeResponse_AffectedRows{
+			AffectedRows: &gpb.AffectedRows{Value: 1},
+		},
+	}, nil
+}
+
+func startFakeDB(t *testing.T, available bool) *fakeDBServer {
+	t.Helper()
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	s := &fakeDBServer{addr: lis.Addr().String(), server: grpc.NewServer()}
+	s.available.Store(available)
+	gpb.RegisterGreptimeDatabaseServer(s.server, s)
+	go func() { _ = s.server.Serve(lis) }()
+	t.Cleanup(s.server.Stop)
+	return s
+}
+
+func failoverTestTable(t *testing.T) *table.Table {
+	t.Helper()
+	tbl, err := table.New("failover_demo")
+	require.NoError(t, err)
+	require.NoError(t, tbl.AddTagColumn("host", types.STRING))
+	require.NoError(t, tbl.AddFieldColumn("cpu", types.FLOAT64))
+	require.NoError(t, tbl.AddTimestampColumn("ts", types.TIMESTAMP_MILLISECOND))
+	require.NoError(t, tbl.AddRow("h", 1.0, time.Now()))
+	return tbl
+}
+
+// TestClientWriteFailsOverToHealthyEndpoint exercises the full public path:
+// a write whose first endpoint is unavailable must succeed on the other one.
+func TestClientWriteFailsOverToHealthyEndpoint(t *testing.T) {
+	down := startFakeDB(t, false)
+	up := startFakeDB(t, true)
+
+	cfg := NewConfig().
+		WithDatabase("public").
+		WithEndpoints(down.addr, up.addr).
+		WithLoadBalancer(loadbalancer.NewRoundRobin()).
+		WithRetry(RetryPolicy{MaxAttempts: 3, InitialBackoff: time.Millisecond, MaxBackoff: 2 * time.Millisecond, BackoffMultiplier: 2})
+	client, err := NewClient(cfg)
+	require.NoError(t, err)
+	defer func() { _ = client.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Several writes: regardless of which endpoint round-robin tries first,
+	// every write must ultimately land on the healthy endpoint.
+	for i := 0; i < 6; i++ {
+		resp, err := client.Write(ctx, failoverTestTable(t))
+		require.NoError(t, err, "write %d should fail over to the healthy endpoint", i)
+		assert.Equal(t, uint32(1), resp.GetAffectedRows().GetValue())
+	}
+	assert.GreaterOrEqual(t, up.calls.Load(), uint64(6), "healthy endpoint served every write")
+}
+
+// TestClientWriteEjectsAndRecoversEndpoint verifies a health-aware selector
+// ejects a failing endpoint from rotation and re-admits it once it recovers.
+func TestClientWriteEjectsAndRecoversEndpoint(t *testing.T) {
+	down := startFakeDB(t, false)
+	up := startFakeDB(t, true)
+
+	detector := loadbalancer.NewOutlierDetector(loadbalancer.OutlierDetectorOptions{
+		Base:                loadbalancer.NewRoundRobin(),
+		ConsecutiveFailures: 1, // eject on first transport failure
+		BaseEjection:        time.Hour,
+	})
+	cfg := NewConfig().
+		WithDatabase("public").
+		WithEndpoints(down.addr, up.addr).
+		WithLoadBalancer(detector).
+		WithRetry(RetryPolicy{MaxAttempts: 3, InitialBackoff: time.Millisecond, MaxBackoff: 2 * time.Millisecond, BackoffMultiplier: 2})
+	client, err := NewClient(cfg)
+	require.NoError(t, err)
+	defer func() { _ = client.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Drive enough writes that the bad endpoint gets selected and ejected.
+	for i := 0; i < 6; i++ {
+		_, err := client.Write(ctx, failoverTestTable(t))
+		require.NoError(t, err)
+	}
+
+	// Once ejected (BaseEjection is an hour), the bad endpoint stops receiving
+	// calls. Record its count, run more writes, and assert it did not grow.
+	ejectedCount := down.calls.Load()
+	for i := 0; i < 6; i++ {
+		_, err := client.Write(ctx, failoverTestTable(t))
+		require.NoError(t, err)
+	}
+	assert.Equal(t, ejectedCount, down.calls.Load(),
+		"ejected endpoint must not be selected while ejected")
+
+	// Recovery: the endpoint comes back and a fresh success re-admits it. We
+	// report success directly to model an out-of-band health probe; subsequent
+	// selection should include it again.
+	down.available.Store(true)
+	detector.ReportSuccess(down.addr)
+	got := map[string]struct{}{}
+	for i := 0; i < 50; i++ {
+		got[detector.Select([]string{down.addr, up.addr}, nil)] = struct{}{}
+	}
+	assert.Contains(t, got, down.addr, "recovered endpoint should re-enter rotation")
+}

--- a/config.go
+++ b/config.go
@@ -204,8 +204,9 @@ func (c *Config) WithLoadBalancer(picker loadbalancer.Picker) *Config {
 }
 
 // WithRetry overrides the retry policy for unary failover. Unary calls (Write,
-// Delete, HealthCheck) retry on retryable transport failures, steering to other
-// healthy endpoints. Defaults to DefaultRetryPolicy when unset.
+// Delete, HealthCheck) retry on retryable transport failures and transient
+// GreptimeDB server errors, steering to other healthy endpoints. Defaults to
+// DefaultRetryPolicy when unset.
 func (c *Config) WithRetry(policy RetryPolicy) *Config {
 	c.retry = &policy
 	return c

--- a/config.go
+++ b/config.go
@@ -50,8 +50,15 @@ type Config struct {
 	endpoints []string
 
 	// picker selects an endpoint per RPC when more than one is configured.
-	// Defaults to loadbalancer.NewRandom() at client construction time.
+	// Defaults to loadbalancer.NewRandom() at client construction time. A
+	// picker that also implements loadbalancer.HealthReporter (e.g.
+	// loadbalancer.NewOutlierDetector) additionally drives health-aware
+	// failover.
 	picker loadbalancer.Picker
+
+	// retry overrides the unary failover retry policy. nil uses
+	// DefaultRetryPolicy.
+	retry *RetryPolicy
 
 	tls     *options.TlsOption
 	options []grpc.DialOption
@@ -188,10 +195,28 @@ func (c *Config) WithEndpoints(endpoints ...string) *Config {
 
 // WithLoadBalancer sets the load-balancing strategy used when more than one
 // endpoint is configured. Defaults to loadbalancer.NewRandom() when unset.
-// Has no observable effect when only a single endpoint is in use.
+// Pass loadbalancer.NewOutlierDetector to enable health-aware failover that
+// temporarily ejects endpoints after consecutive transport failures. Has no
+// observable effect when only a single endpoint is in use.
 func (c *Config) WithLoadBalancer(picker loadbalancer.Picker) *Config {
 	c.picker = picker
 	return c
+}
+
+// WithRetry overrides the retry policy for unary failover. Unary calls (Write,
+// Delete, HealthCheck) retry on retryable transport failures, steering to other
+// healthy endpoints. Defaults to DefaultRetryPolicy when unset.
+func (c *Config) WithRetry(policy RetryPolicy) *Config {
+	c.retry = &policy
+	return c
+}
+
+// retryPolicy returns the configured policy, falling back to the default.
+func (c *Config) retryPolicy() RetryPolicy {
+	if c.retry != nil {
+		return *c.retry
+	}
+	return DefaultRetryPolicy
 }
 
 // resolveEndpoints returns the configured endpoints, falling back to

--- a/examples/multi_endpoint/main.go
+++ b/examples/multi_endpoint/main.go
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-// Writes to several GreptimeDB endpoints with client-side load balancing.
+// Writes to several GreptimeDB endpoints with client-side load balancing and
+// health-aware failover.
 package main
 
 import (
@@ -34,7 +35,22 @@ func main() {
 	cfg := greptime.NewConfig().
 		WithDatabase(database).
 		WithEndpoints("127.0.0.1:4001", "127.0.0.2:4001", "127.0.0.3:4001").
-		WithLoadBalancer(loadbalancer.NewRoundRobin()) // default is NewRandom()
+		// Health-aware failover: eject an endpoint after consecutive transport
+		// failures and round-robin among the healthy ones. Drop this call to use
+		// the default stateless NewRandom() picker.
+		WithLoadBalancer(loadbalancer.NewOutlierDetector(loadbalancer.OutlierDetectorOptions{
+			Base:                loadbalancer.NewRoundRobin(),
+			ConsecutiveFailures: 3,
+			BaseEjection:        30 * time.Second,
+		})).
+		// Retry retryable transport failures on another healthy endpoint.
+		WithRetry(greptime.RetryPolicy{
+			MaxAttempts:       3,
+			InitialBackoff:    100 * time.Millisecond,
+			MaxBackoff:        5 * time.Second,
+			BackoffMultiplier: 2,
+			Jitter:            true,
+		})
 
 	client, err := greptime.NewClient(cfg)
 	if err != nil {

--- a/failover.go
+++ b/failover.go
@@ -59,14 +59,21 @@ var DefaultRetryPolicy = RetryPolicy{
 }
 
 // isRetryable reports whether err is a transient transport failure worth
-// retrying on another endpoint. The retryable set mirrors the TypeScript
-// ingester's conservative codes. Caller-initiated cancellation never retries.
+// retrying on another endpoint.
+//
+// DeadlineExceeded is deliberately NOT retryable: this client forwards the
+// caller's context straight to each RPC (there is no per-attempt deadline), so
+// a DeadlineExceeded means the caller's own deadline elapsed. Retrying would
+// reuse the same expired context and is pointless. The cancellation guard keeps
+// a wrapped context.Canceled (which has no gRPC status, so it would otherwise
+// classify as Unknown) from being treated as retryable; runWithFailover's own
+// context check is the primary stop for caller cancellation.
 func isRetryable(err error) bool {
-	if err == nil || isCancellation(err) {
+	if isCancellation(err) {
 		return false
 	}
 	switch status.Code(err) {
-	case codes.Unknown, codes.DeadlineExceeded, codes.ResourceExhausted, codes.Aborted, codes.Unavailable:
+	case codes.Unknown, codes.ResourceExhausted, codes.Aborted, codes.Unavailable:
 		return true
 	default:
 		return false
@@ -77,20 +84,22 @@ func isRetryable(err error) bool {
 // unhealthy (connectivity or capacity) and should be temporarily avoided by a
 // health-aware selector. A server business error — even a retryable one — means
 // the endpoint is alive and routing correctly and must NOT eject it.
+//
+// DeadlineExceeded is excluded for the same reason as in isRetryable: it
+// reflects the caller's clock, not the endpoint's health, so a tight caller
+// deadline must never eject an otherwise-healthy endpoint.
 func isEndpointFailure(err error) bool {
-	if err == nil || isCancellation(err) {
-		return false
-	}
 	switch status.Code(err) {
-	case codes.DeadlineExceeded, codes.ResourceExhausted, codes.Unavailable:
+	case codes.ResourceExhausted, codes.Unavailable:
 		return true
 	default:
 		return false
 	}
 }
 
-// isCancellation reports whether err is a caller-initiated cancellation, which
-// says nothing about endpoint health and must never be retried.
+// isCancellation reports whether err is a server-returned cancellation, which
+// says nothing about endpoint health. Caller-initiated cancellation/deadline is
+// detected via the context directly (see runWithFailover), not here.
 func isCancellation(err error) bool {
 	return errors.Is(err, context.Canceled) || status.Code(err) == codes.Canceled
 }
@@ -130,12 +139,19 @@ func runWithFailover[T any](
 
 		peer := selector.Select(addrs, failed)
 		res, err := call(peer)
-		reportOutcome(health, peer, err)
 		if err == nil {
+			reportOutcome(health, peer, nil)
 			return res, nil
+		}
+		// Caller-initiated cancellation or deadline: the endpoint may be
+		// perfectly healthy, the caller simply ran out of time. Stop without
+		// retrying and without blaming the endpoint's health.
+		if ctx.Err() != nil {
+			return zero, err
 		}
 
 		failed[peer] = struct{}{}
+		reportOutcome(health, peer, err)
 		lastErr = err
 		if attempt == attempts-1 || !isRetryable(err) {
 			break

--- a/failover.go
+++ b/failover.go
@@ -58,44 +58,35 @@ var DefaultRetryPolicy = RetryPolicy{
 	Jitter:            true,
 }
 
-// retryableCodes are transport-level gRPC status codes worth retrying on
-// another endpoint. Mirrors the TypeScript ingester's conservative set.
-var retryableCodes = map[codes.Code]struct{}{
-	codes.Unknown:           {},
-	codes.DeadlineExceeded:  {},
-	codes.ResourceExhausted: {},
-	codes.Aborted:           {},
-	codes.Unavailable:       {},
-}
-
-// endpointFailureCodes indicate the endpoint itself is unhealthy (connectivity
-// or capacity), so a health-aware selector should temporarily avoid it. A
-// server business error — even a retryable one — means the endpoint is alive
-// and routing correctly and must NOT eject it.
-var endpointFailureCodes = map[codes.Code]struct{}{
-	codes.DeadlineExceeded:  {},
-	codes.ResourceExhausted: {},
-	codes.Unavailable:       {},
-}
-
 // isRetryable reports whether err is a transient transport failure worth
-// retrying on another endpoint. Caller-initiated cancellation never retries.
+// retrying on another endpoint. The retryable set mirrors the TypeScript
+// ingester's conservative codes. Caller-initiated cancellation never retries.
 func isRetryable(err error) bool {
 	if err == nil || isCancellation(err) {
 		return false
 	}
-	_, ok := retryableCodes[status.Code(err)]
-	return ok
+	switch status.Code(err) {
+	case codes.Unknown, codes.DeadlineExceeded, codes.ResourceExhausted, codes.Aborted, codes.Unavailable:
+		return true
+	default:
+		return false
+	}
 }
 
 // isEndpointFailure reports whether err indicates the endpoint itself is
-// unhealthy and should be temporarily avoided by a health-aware selector.
+// unhealthy (connectivity or capacity) and should be temporarily avoided by a
+// health-aware selector. A server business error — even a retryable one — means
+// the endpoint is alive and routing correctly and must NOT eject it.
 func isEndpointFailure(err error) bool {
 	if err == nil || isCancellation(err) {
 		return false
 	}
-	_, ok := endpointFailureCodes[status.Code(err)]
-	return ok
+	switch status.Code(err) {
+	case codes.DeadlineExceeded, codes.ResourceExhausted, codes.Unavailable:
+		return true
+	default:
+		return false
+	}
 }
 
 // isCancellation reports whether err is a caller-initiated cancellation, which

--- a/failover.go
+++ b/failover.go
@@ -21,9 +21,11 @@ import (
 	"errors"
 	"math"
 	"math/rand/v2"
+	"strconv"
 	"time"
 
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
 	"github.com/GreptimeTeam/greptimedb-ingester-go/loadbalancer"
@@ -58,8 +60,75 @@ var DefaultRetryPolicy = RetryPolicy{
 	Jitter:            true,
 }
 
-// isRetryable reports whether err is a transient transport failure worth
-// retrying on another endpoint.
+// greptimeErrCodeTrailer is the gRPC trailer key under which GreptimeDB returns
+// its business StatusCode on an errored response (mirrors the server-side
+// common_error::GREPTIME_DB_HEADER_ERROR_CODE).
+const greptimeErrCodeTrailer = "x-greptime-err-code"
+
+// retryableServerStatus is the set of GreptimeDB business status codes that are
+// transient and worth retrying. Mirrors StatusCode::is_retryable in GreptimeDB,
+// minus Internal (1003): a generic internal error is too often a real bug to
+// retry blindly. Same set the TypeScript ingester uses.
+//
+// These are needed because the server's status_code -> gRPC code mapping is
+// lossy: RegionBusy and RateLimited both surface as ResourceExhausted, but only
+// RegionBusy is retryable. Classifying on the precise status code restores the
+// distinction.
+var retryableServerStatus = map[uint32]struct{}{
+	4008: {}, // RegionNotReady
+	4009: {}, // RegionBusy
+	4010: {}, // TableUnavailable
+	5000: {}, // StorageUnavailable
+	6000: {}, // RuntimeResourcesExhausted
+}
+
+// serverStatusError pairs a gRPC status error from GreptimeDB with the business
+// StatusCode carried in the x-greptime-err-code trailer. It is unexported and
+// transparent: it preserves the underlying gRPC status (GRPCStatus) and error
+// chain (Unwrap), so callers still see the original error — it only steers
+// retry/health classification internally.
+type serverStatusError struct {
+	statusCode uint32
+	err        error
+}
+
+func (e *serverStatusError) Error() string              { return e.err.Error() }
+func (e *serverStatusError) Unwrap() error              { return e.err }
+func (e *serverStatusError) GRPCStatus() *status.Status { return status.Convert(e.err) }
+
+// withServerStatus annotates err with the GreptimeDB business status code from
+// the response trailer when present. A nil error or a trailer without the code
+// is returned unchanged.
+func withServerStatus(err error, trailer metadata.MD) error {
+	if err == nil {
+		return nil
+	}
+	vals := trailer.Get(greptimeErrCodeTrailer)
+	if len(vals) == 0 {
+		return err
+	}
+	code, parseErr := strconv.ParseUint(vals[0], 10, 32)
+	if parseErr != nil {
+		return err
+	}
+	return &serverStatusError{statusCode: uint32(code), err: err}
+}
+
+// serverStatusCode returns the GreptimeDB business status code carried by err,
+// if err is a server status error.
+func serverStatusCode(err error) (uint32, bool) {
+	var se *serverStatusError
+	if errors.As(err, &se) {
+		return se.statusCode, true
+	}
+	return 0, false
+}
+
+// isRetryable reports whether err is worth retrying on another endpoint.
+//
+// A GreptimeDB business error is authoritative: only its transient status codes
+// retry, regardless of how they collapse onto gRPC codes. Otherwise we fall
+// back to the transport-level gRPC codes.
 //
 // DeadlineExceeded is deliberately NOT retryable: this client forwards the
 // caller's context straight to each RPC (there is no per-attempt deadline), so
@@ -72,6 +141,10 @@ func isRetryable(err error) bool {
 	if isCancellation(err) {
 		return false
 	}
+	if code, ok := serverStatusCode(err); ok {
+		_, retry := retryableServerStatus[code]
+		return retry
+	}
 	switch status.Code(err) {
 	case codes.Unknown, codes.ResourceExhausted, codes.Aborted, codes.Unavailable:
 		return true
@@ -82,13 +155,17 @@ func isRetryable(err error) bool {
 
 // isEndpointFailure reports whether err indicates the endpoint itself is
 // unhealthy (connectivity or capacity) and should be temporarily avoided by a
-// health-aware selector. A server business error — even a retryable one — means
-// the endpoint is alive and routing correctly and must NOT eject it.
+// health-aware selector.
 //
+// A server business error — even a retryable one like RegionBusy — means the
+// endpoint answered and is routing correctly, so it must NOT eject the endpoint
+// (that would punish a healthy frontend for a datanode-side condition).
 // DeadlineExceeded is excluded for the same reason as in isRetryable: it
-// reflects the caller's clock, not the endpoint's health, so a tight caller
-// deadline must never eject an otherwise-healthy endpoint.
+// reflects the caller's clock, not the endpoint's health.
 func isEndpointFailure(err error) bool {
+	if _, ok := serverStatusCode(err); ok {
+		return false
+	}
 	switch status.Code(err) {
 	case codes.ResourceExhausted, codes.Unavailable:
 		return true

--- a/failover.go
+++ b/failover.go
@@ -32,8 +32,9 @@ import (
 )
 
 // RetryPolicy controls how unary calls (Write, Delete, HealthCheck) are retried
-// across endpoints on retryable transport failures. Streaming and bulk calls
-// are not auto-retried; see the package README.
+// across endpoints on retryable transport failures and transient GreptimeDB
+// server errors. Streaming and bulk calls are not auto-retried; see the package
+// README.
 type RetryPolicy struct {
 	// MaxAttempts is the total number of attempts including the first. Values
 	// below 1 are treated as 1 (no retry).
@@ -208,9 +209,6 @@ func runWithFailover[T any](
 	var lastErr error
 	for attempt := 0; attempt < attempts; attempt++ {
 		if err := ctx.Err(); err != nil {
-			if lastErr != nil {
-				return zero, lastErr
-			}
 			return zero, err
 		}
 
@@ -264,7 +262,7 @@ func reportOutcome(health loadbalancer.HealthReporter, peer string, err error) {
 func sleepBackoff(ctx context.Context, policy RetryPolicy, attempt int) error {
 	d := computeBackoff(policy, attempt)
 	if d <= 0 {
-		return ctx.Err()
+		return nil
 	}
 	t := time.NewTimer(d)
 	defer t.Stop()

--- a/failover.go
+++ b/failover.go
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2026 Greptime Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package greptime
+
+import (
+	"context"
+	"errors"
+	"math"
+	"math/rand/v2"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/GreptimeTeam/greptimedb-ingester-go/loadbalancer"
+)
+
+// RetryPolicy controls how unary calls (Write, Delete, HealthCheck) are retried
+// across endpoints on retryable transport failures. Streaming and bulk calls
+// are not auto-retried; see the package README.
+type RetryPolicy struct {
+	// MaxAttempts is the total number of attempts including the first. Values
+	// below 1 are treated as 1 (no retry).
+	MaxAttempts int
+	// InitialBackoff is the base delay before the first retry.
+	InitialBackoff time.Duration
+	// MaxBackoff caps the per-retry delay.
+	MaxBackoff time.Duration
+	// BackoffMultiplier grows the delay each retry
+	// (delay = InitialBackoff * BackoffMultiplier^attempt).
+	BackoffMultiplier float64
+	// Jitter, when true, applies full jitter: the actual delay is uniform in
+	// [0, computed]. Recommended to avoid synchronized retries across clients.
+	Jitter bool
+}
+
+// DefaultRetryPolicy mirrors the TypeScript ingester defaults: three attempts
+// with exponential backoff and full jitter.
+var DefaultRetryPolicy = RetryPolicy{
+	MaxAttempts:       3,
+	InitialBackoff:    100 * time.Millisecond,
+	MaxBackoff:        5 * time.Second,
+	BackoffMultiplier: 2,
+	Jitter:            true,
+}
+
+// retryableCodes are transport-level gRPC status codes worth retrying on
+// another endpoint. Mirrors the TypeScript ingester's conservative set.
+var retryableCodes = map[codes.Code]struct{}{
+	codes.Unknown:           {},
+	codes.DeadlineExceeded:  {},
+	codes.ResourceExhausted: {},
+	codes.Aborted:           {},
+	codes.Unavailable:       {},
+}
+
+// endpointFailureCodes indicate the endpoint itself is unhealthy (connectivity
+// or capacity), so a health-aware selector should temporarily avoid it. A
+// server business error — even a retryable one — means the endpoint is alive
+// and routing correctly and must NOT eject it.
+var endpointFailureCodes = map[codes.Code]struct{}{
+	codes.DeadlineExceeded:  {},
+	codes.ResourceExhausted: {},
+	codes.Unavailable:       {},
+}
+
+// isRetryable reports whether err is a transient transport failure worth
+// retrying on another endpoint. Caller-initiated cancellation never retries.
+func isRetryable(err error) bool {
+	if err == nil || isCancellation(err) {
+		return false
+	}
+	_, ok := retryableCodes[status.Code(err)]
+	return ok
+}
+
+// isEndpointFailure reports whether err indicates the endpoint itself is
+// unhealthy and should be temporarily avoided by a health-aware selector.
+func isEndpointFailure(err error) bool {
+	if err == nil || isCancellation(err) {
+		return false
+	}
+	_, ok := endpointFailureCodes[status.Code(err)]
+	return ok
+}
+
+// isCancellation reports whether err is a caller-initiated cancellation, which
+// says nothing about endpoint health and must never be retried.
+func isCancellation(err error) bool {
+	return errors.Is(err, context.Canceled) || status.Code(err) == codes.Canceled
+}
+
+// runWithFailover executes call across endpoints with bounded retries and
+// optional health feedback. It is transport-agnostic — call resolves the peer
+// to a concrete RPC — so the loop stays unit-testable without a live server.
+//
+// On each attempt it asks the selector for a peer, excluding peers that already
+// failed in this sequence so a single dead endpoint cannot burn the whole retry
+// budget. Outcomes feed the health reporter (when non-nil): a transport-level
+// endpoint failure ejects, while a success or a server business error (the
+// endpoint answered) clears the streak.
+func runWithFailover[T any](
+	ctx context.Context,
+	addrs []string,
+	selector loadbalancer.Selector,
+	health loadbalancer.HealthReporter,
+	policy RetryPolicy,
+	call func(peer string) (T, error),
+) (T, error) {
+	var zero T
+	attempts := policy.MaxAttempts
+	if attempts < 1 {
+		attempts = 1
+	}
+
+	failed := make(map[string]struct{})
+	var lastErr error
+	for attempt := 0; attempt < attempts; attempt++ {
+		if err := ctx.Err(); err != nil {
+			if lastErr != nil {
+				return zero, lastErr
+			}
+			return zero, err
+		}
+
+		peer := selector.Select(addrs, failed)
+		res, err := call(peer)
+		reportOutcome(health, peer, err)
+		if err == nil {
+			return res, nil
+		}
+
+		failed[peer] = struct{}{}
+		lastErr = err
+		if attempt == attempts-1 || !isRetryable(err) {
+			break
+		}
+		if werr := sleepBackoff(ctx, policy, attempt); werr != nil {
+			return zero, werr
+		}
+	}
+	return zero, lastErr
+}
+
+// reportOutcome maps a single endpoint-bound outcome to the selector's health
+// hooks. A client-side error never reaches here (request building happens
+// before the call), so within the loop an error is always an RPC verdict: a
+// transport failure ejects, anything else means the endpoint answered.
+func reportOutcome(health loadbalancer.HealthReporter, peer string, err error) {
+	if health == nil {
+		return
+	}
+	switch {
+	case err == nil:
+		health.ReportSuccess(peer)
+	case isCancellation(err):
+		// Caller-initiated; says nothing about the endpoint.
+	case isEndpointFailure(err):
+		health.ReportFailure(peer)
+	default:
+		// The endpoint answered with a business error → it is alive.
+		health.ReportSuccess(peer)
+	}
+}
+
+func sleepBackoff(ctx context.Context, policy RetryPolicy, attempt int) error {
+	d := computeBackoff(policy, attempt)
+	if d <= 0 {
+		return ctx.Err()
+	}
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.C:
+		return nil
+	}
+}
+
+func computeBackoff(policy RetryPolicy, attempt int) time.Duration {
+	base := float64(policy.InitialBackoff) * math.Pow(policy.BackoffMultiplier, float64(attempt))
+	if maxB := float64(policy.MaxBackoff); maxB > 0 && base > maxB {
+		base = maxB
+	}
+	if policy.Jitter {
+		base *= rand.Float64()
+	}
+	return time.Duration(base)
+}

--- a/failover_test.go
+++ b/failover_test.go
@@ -1,0 +1,260 @@
+/*
+ * Copyright 2026 Greptime Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package greptime
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// recordingSelector records every Select call and its exclude snapshot, plus
+// the health-hook calls. It returns the first non-excluded endpoint (falling
+// open to the first endpoint), so exclusion is observable. It implements both
+// loadbalancer.Selector and loadbalancer.HealthReporter.
+type recordingSelector struct {
+	selects   []selectCall
+	successes []string
+	failures  []string
+}
+
+type selectCall struct {
+	peer    string
+	exclude []string
+}
+
+func (s *recordingSelector) Pick(endpoints []string) string {
+	return s.Select(endpoints, nil)
+}
+
+func (s *recordingSelector) Select(endpoints []string, exclude map[string]struct{}) string {
+	peer := endpoints[0]
+	for _, ep := range endpoints {
+		if _, skip := exclude[ep]; !skip {
+			peer = ep
+			break
+		}
+	}
+	keys := make([]string, 0, len(exclude))
+	for ep := range exclude {
+		keys = append(keys, ep)
+	}
+	s.selects = append(s.selects, selectCall{peer: peer, exclude: keys})
+	return peer
+}
+
+func (s *recordingSelector) ReportSuccess(endpoint string) {
+	s.successes = append(s.successes, endpoint)
+}
+func (s *recordingSelector) ReportFailure(endpoint string) { s.failures = append(s.failures, endpoint) }
+
+var testAddrs = []string{"h1:4001", "h2:4001"}
+
+func fastRetry() RetryPolicy {
+	return RetryPolicy{MaxAttempts: 3, InitialBackoff: time.Millisecond, MaxBackoff: 2 * time.Millisecond, BackoffMultiplier: 2}
+}
+
+func unavailable() error { return status.Error(codes.Unavailable, "down") }
+
+func TestFailoverExcludesFailedPeersThenSucceeds(t *testing.T) {
+	sel := &recordingSelector{}
+	errs := []error{unavailable(), unavailable(), nil}
+	var calls int
+
+	res, err := runWithFailover(context.Background(), testAddrs, sel, sel, fastRetry(),
+		func(peer string) (int, error) {
+			e := errs[calls]
+			calls++
+			if e != nil {
+				return 0, e
+			}
+			return 7, nil
+		})
+
+	require.NoError(t, err)
+	assert.Equal(t, 7, res)
+	require.Len(t, sel.selects, 3)
+	assert.Empty(t, sel.selects[0].exclude)
+	assert.Contains(t, sel.selects[1].exclude, "h1:4001")
+	assert.ElementsMatch(t, []string{"h1:4001", "h2:4001"}, sel.selects[2].exclude)
+}
+
+func TestFailoverReportsEndpointFailureButNotBusinessError(t *testing.T) {
+	sel := &recordingSelector{}
+	// First: transport failure → endpoint failure. Second: a business error
+	// (the endpoint answered, so it is alive) → must not eject. Third: success.
+	errs := []error{unavailable(), status.Error(codes.InvalidArgument, "bad"), nil}
+	var calls int
+
+	_, err := runWithFailover(context.Background(), testAddrs, sel, sel, fastRetry(),
+		func(peer string) (int, error) {
+			e := errs[calls]
+			calls++
+			return 0, e
+		})
+
+	// The InvalidArgument is non-retryable, so the loop stops at attempt 2.
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+	assert.Equal(t, []string{"h1:4001"}, sel.failures)
+	assert.Contains(t, sel.successes, "h2:4001")
+}
+
+func TestFailoverStopsOnNonRetryableError(t *testing.T) {
+	sel := &recordingSelector{}
+	var calls int
+
+	_, err := runWithFailover(context.Background(), testAddrs, sel, sel, fastRetry(),
+		func(peer string) (int, error) {
+			calls++
+			return 0, status.Error(codes.InvalidArgument, "bad")
+		})
+
+	require.Error(t, err)
+	assert.Equal(t, 1, calls, "non-retryable error must not retry")
+	require.Len(t, sel.selects, 1)
+	// A business error proves the endpoint is alive — reported as success.
+	assert.Empty(t, sel.failures)
+	assert.Equal(t, []string{"h1:4001"}, sel.successes)
+}
+
+func TestFailoverExhaustsAttemptsAndReturnsLastError(t *testing.T) {
+	sel := &recordingSelector{}
+	var calls int
+
+	_, err := runWithFailover(context.Background(), testAddrs, sel, sel, fastRetry(),
+		func(peer string) (int, error) {
+			calls++
+			return 0, unavailable()
+		})
+
+	require.Error(t, err)
+	assert.Equal(t, codes.Unavailable, status.Code(err))
+	assert.Equal(t, 3, calls, "should try MaxAttempts times")
+	assert.Len(t, sel.failures, 3)
+}
+
+func TestFailoverNoHealthReporterStillExcludes(t *testing.T) {
+	sel := &recordingSelector{}
+	errs := []error{unavailable(), nil}
+	var calls int
+
+	// Pass nil health: stateless picker case. Exclude steering must still work.
+	res, err := runWithFailover(context.Background(), testAddrs, sel, nil, fastRetry(),
+		func(peer string) (int, error) {
+			e := errs[calls]
+			calls++
+			if e != nil {
+				return 0, e
+			}
+			return 1, nil
+		})
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, res)
+	assert.Empty(t, sel.successes, "nil health reporter records nothing")
+	assert.Empty(t, sel.failures)
+	assert.Contains(t, sel.selects[1].exclude, "h1:4001")
+}
+
+func TestFailoverHonorsCancelledContext(t *testing.T) {
+	sel := &recordingSelector{}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := runWithFailover(ctx, testAddrs, sel, sel, fastRetry(),
+		func(peer string) (int, error) { return 1, nil })
+
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Empty(t, sel.selects, "must not attempt with a cancelled context")
+}
+
+func TestFailoverCancellationDuringBackoffStops(t *testing.T) {
+	sel := &recordingSelector{}
+	ctx, cancel := context.WithCancel(context.Background())
+	policy := RetryPolicy{MaxAttempts: 3, InitialBackoff: time.Hour, MaxBackoff: time.Hour, BackoffMultiplier: 2}
+
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	_, err := runWithFailover(ctx, testAddrs, sel, sel, policy,
+		func(peer string) (int, error) { return 0, unavailable() })
+
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestIsRetryable(t *testing.T) {
+	assert.True(t, isRetryable(status.Error(codes.Unavailable, "")))
+	assert.True(t, isRetryable(status.Error(codes.DeadlineExceeded, "")))
+	assert.True(t, isRetryable(status.Error(codes.ResourceExhausted, "")))
+	assert.True(t, isRetryable(status.Error(codes.Aborted, "")))
+	assert.True(t, isRetryable(status.Error(codes.Unknown, "")))
+
+	assert.False(t, isRetryable(nil))
+	assert.False(t, isRetryable(status.Error(codes.InvalidArgument, "")))
+	assert.False(t, isRetryable(status.Error(codes.NotFound, "")))
+	assert.False(t, isRetryable(status.Error(codes.Canceled, "")))
+	assert.False(t, isRetryable(context.Canceled))
+}
+
+func TestIsEndpointFailure(t *testing.T) {
+	assert.True(t, isEndpointFailure(status.Error(codes.Unavailable, "")))
+	assert.True(t, isEndpointFailure(status.Error(codes.DeadlineExceeded, "")))
+	assert.True(t, isEndpointFailure(status.Error(codes.ResourceExhausted, "")))
+
+	// Retryable transient but not an endpoint-health signal.
+	assert.False(t, isEndpointFailure(status.Error(codes.Aborted, "")))
+	assert.False(t, isEndpointFailure(status.Error(codes.Unknown, "")))
+	// Business errors: the endpoint answered.
+	assert.False(t, isEndpointFailure(status.Error(codes.InvalidArgument, "")))
+	assert.False(t, isEndpointFailure(nil))
+	assert.False(t, isEndpointFailure(context.Canceled))
+}
+
+func TestComputeBackoffCapsAndGrows(t *testing.T) {
+	policy := RetryPolicy{InitialBackoff: 100 * time.Millisecond, MaxBackoff: 500 * time.Millisecond, BackoffMultiplier: 2}
+	assert.Equal(t, 100*time.Millisecond, computeBackoff(policy, 0))
+	assert.Equal(t, 200*time.Millisecond, computeBackoff(policy, 1))
+	assert.Equal(t, 400*time.Millisecond, computeBackoff(policy, 2))
+	// 100 * 2^3 = 800 > 500 cap.
+	assert.Equal(t, 500*time.Millisecond, computeBackoff(policy, 3))
+}
+
+func TestComputeBackoffFullJitterWithinBounds(t *testing.T) {
+	policy := RetryPolicy{InitialBackoff: 100 * time.Millisecond, MaxBackoff: time.Second, BackoffMultiplier: 2, Jitter: true}
+	for i := 0; i < 100; i++ {
+		d := computeBackoff(policy, 1) // base 200ms
+		assert.GreaterOrEqual(t, d, time.Duration(0))
+		assert.LessOrEqual(t, d, 200*time.Millisecond)
+	}
+}
+
+// Sanity: the wrapper produced by errors.Is on a wrapped cancellation is treated
+// as a cancellation, not a retryable transport failure.
+func TestWrappedCancellationNotRetryable(t *testing.T) {
+	wrapped := errors.Join(errors.New("ctx"), context.Canceled)
+	assert.True(t, isCancellation(wrapped))
+	assert.False(t, isRetryable(wrapped))
+}

--- a/failover_test.go
+++ b/failover_test.go
@@ -78,6 +78,13 @@ func (s *recordingSelector) ReportSuccess(endpoint string) {
 }
 func (s *recordingSelector) ReportFailure(endpoint string) { s.failures = append(s.failures, endpoint) }
 
+type cancelOnFailure struct {
+	cancel func()
+}
+
+func (h cancelOnFailure) ReportSuccess(endpoint string) {}
+func (h cancelOnFailure) ReportFailure(endpoint string) { h.cancel() }
+
 var testAddrs = []string{"h1:4001", "h2:4001"}
 
 func fastRetry() RetryPolicy {
@@ -213,6 +220,22 @@ func TestFailoverCancellationDuringBackoffStops(t *testing.T) {
 		func(peer string) (int, error) { return 0, unavailable() })
 
 	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestFailoverCancelledBeforeNextAttemptReturnsContextError(t *testing.T) {
+	sel := &recordingSelector{}
+	ctx, cancel := context.WithCancel(context.Background())
+	policy := RetryPolicy{MaxAttempts: 3, InitialBackoff: 0, MaxBackoff: 0, BackoffMultiplier: 2}
+	var calls int
+
+	_, err := runWithFailover(ctx, testAddrs, sel, cancelOnFailure{cancel: cancel}, policy,
+		func(peer string) (int, error) {
+			calls++
+			return 0, unavailable()
+		})
+
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, calls, "must stop before the next attempt")
 }
 
 func TestIsRetryable(t *testing.T) {

--- a/failover_test.go
+++ b/failover_test.go
@@ -207,11 +207,13 @@ func TestFailoverCancellationDuringBackoffStops(t *testing.T) {
 
 func TestIsRetryable(t *testing.T) {
 	assert.True(t, isRetryable(status.Error(codes.Unavailable, "")))
-	assert.True(t, isRetryable(status.Error(codes.DeadlineExceeded, "")))
 	assert.True(t, isRetryable(status.Error(codes.ResourceExhausted, "")))
 	assert.True(t, isRetryable(status.Error(codes.Aborted, "")))
 	assert.True(t, isRetryable(status.Error(codes.Unknown, "")))
 
+	// DeadlineExceeded is the caller's elapsed deadline (no per-attempt
+	// deadline exists) — retrying reuses the same expired context.
+	assert.False(t, isRetryable(status.Error(codes.DeadlineExceeded, "")))
 	assert.False(t, isRetryable(nil))
 	assert.False(t, isRetryable(status.Error(codes.InvalidArgument, "")))
 	assert.False(t, isRetryable(status.Error(codes.NotFound, "")))
@@ -221,9 +223,10 @@ func TestIsRetryable(t *testing.T) {
 
 func TestIsEndpointFailure(t *testing.T) {
 	assert.True(t, isEndpointFailure(status.Error(codes.Unavailable, "")))
-	assert.True(t, isEndpointFailure(status.Error(codes.DeadlineExceeded, "")))
 	assert.True(t, isEndpointFailure(status.Error(codes.ResourceExhausted, "")))
 
+	// DeadlineExceeded reflects the caller's clock, not endpoint health.
+	assert.False(t, isEndpointFailure(status.Error(codes.DeadlineExceeded, "")))
 	// Retryable transient but not an endpoint-health signal.
 	assert.False(t, isEndpointFailure(status.Error(codes.Aborted, "")))
 	assert.False(t, isEndpointFailure(status.Error(codes.Unknown, "")))
@@ -231,6 +234,28 @@ func TestIsEndpointFailure(t *testing.T) {
 	assert.False(t, isEndpointFailure(status.Error(codes.InvalidArgument, "")))
 	assert.False(t, isEndpointFailure(nil))
 	assert.False(t, isEndpointFailure(context.Canceled))
+}
+
+// A caller deadline/cancel that fires while the RPC is in flight must stop
+// immediately: no retry, and no health penalty against the endpoint (it may be
+// perfectly healthy — the caller simply ran out of time).
+func TestFailoverCallerDeadlineNotRetriedNorReported(t *testing.T) {
+	sel := &recordingSelector{}
+	ctx, cancel := context.WithCancel(context.Background())
+	var calls int
+
+	_, err := runWithFailover(ctx, testAddrs, sel, sel, fastRetry(),
+		func(peer string) (int, error) {
+			calls++
+			cancel() // caller's context elapses during the RPC
+			return 0, status.Error(codes.DeadlineExceeded, "deadline")
+		})
+
+	require.Error(t, err)
+	assert.Equal(t, codes.DeadlineExceeded, status.Code(err))
+	assert.Equal(t, 1, calls, "caller deadline must not trigger a retry")
+	assert.Empty(t, sel.failures, "caller deadline must not eject the endpoint")
+	assert.Empty(t, sel.successes)
 }
 
 func TestComputeBackoffCapsAndGrows(t *testing.T) {

--- a/failover_test.go
+++ b/failover_test.go
@@ -19,14 +19,24 @@ package greptime
 import (
 	"context"
 	"errors"
+	"strconv"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
+
+// serverErr builds the kind of error the unary path produces for a GreptimeDB
+// business failure: a gRPC status error annotated with the precise status code
+// from the x-greptime-err-code trailer.
+func serverErr(grpcCode codes.Code, statusCode uint32) error {
+	md := metadata.Pairs(greptimeErrCodeTrailer, strconv.FormatUint(uint64(statusCode), 10))
+	return withServerStatus(status.Error(grpcCode, "server"), md)
+}
 
 // recordingSelector records every Select call and its exclude snapshot, plus
 // the health-hook calls. It returns the first non-excluded endpoint (falling
@@ -234,6 +244,51 @@ func TestIsEndpointFailure(t *testing.T) {
 	assert.False(t, isEndpointFailure(status.Error(codes.InvalidArgument, "")))
 	assert.False(t, isEndpointFailure(nil))
 	assert.False(t, isEndpointFailure(context.Canceled))
+}
+
+// GreptimeDB collapses several business status codes onto the same gRPC code
+// (RegionBusy and RateLimited both become ResourceExhausted; RegionNotReady and
+// TableNotFound differ only by status code under Unavailable/NotFound). The
+// precise status code from the trailer must drive the retry decision.
+func TestServerStatusErrorRetryClassification(t *testing.T) {
+	// Retryable transient business errors.
+	assert.True(t, isRetryable(serverErr(codes.ResourceExhausted, 4009)), "RegionBusy")
+	assert.True(t, isRetryable(serverErr(codes.Unavailable, 4008)), "RegionNotReady")
+	assert.True(t, isRetryable(serverErr(codes.Unavailable, 4010)), "TableUnavailable")
+	assert.True(t, isRetryable(serverErr(codes.Unavailable, 5000)), "StorageUnavailable")
+	assert.True(t, isRetryable(serverErr(codes.ResourceExhausted, 6000)), "RuntimeResourcesExhausted")
+
+	// Same gRPC code, non-retryable status code: must NOT retry despite mapping
+	// to ResourceExhausted/Unavailable.
+	assert.False(t, isRetryable(serverErr(codes.ResourceExhausted, 6001)), "RateLimited")
+	assert.False(t, isRetryable(serverErr(codes.Internal, 1003)), "Internal (a real bug, not retried)")
+	assert.False(t, isRetryable(serverErr(codes.NotFound, 4001)), "TableNotFound")
+	assert.False(t, isRetryable(serverErr(codes.InvalidArgument, 1004)), "InvalidArguments")
+}
+
+func TestServerStatusErrorNeverEjectsEndpoint(t *testing.T) {
+	// A business error — even a retryable one — proves the endpoint is alive.
+	assert.False(t, isEndpointFailure(serverErr(codes.ResourceExhausted, 4009)), "RegionBusy")
+	assert.False(t, isEndpointFailure(serverErr(codes.Unavailable, 4008)), "RegionNotReady")
+	assert.False(t, isEndpointFailure(serverErr(codes.Internal, 1003)))
+
+	// A bare transport failure (no trailer) still ejects.
+	assert.True(t, isEndpointFailure(status.Error(codes.Unavailable, "")))
+	assert.True(t, isEndpointFailure(status.Error(codes.ResourceExhausted, "")))
+}
+
+func TestWithServerStatusTransparent(t *testing.T) {
+	// nil and trailer-less errors pass through unchanged.
+	assert.Nil(t, withServerStatus(nil, metadata.MD{}))
+	plain := status.Error(codes.Unavailable, "down")
+	assert.Equal(t, plain, withServerStatus(plain, metadata.MD{}))
+
+	// The wrapper preserves gRPC status code and the error chain.
+	wrapped := serverErr(codes.ResourceExhausted, 4009)
+	assert.Equal(t, codes.ResourceExhausted, status.Code(wrapped), "GRPCStatus preserved")
+	code, ok := serverStatusCode(wrapped)
+	assert.True(t, ok)
+	assert.Equal(t, uint32(4009), code)
 }
 
 // A caller deadline/cancel that fires while the RPC is in flight must stop

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
-// Package pool manages a set of gRPC connections to GreptimeDB endpoints and
-// dispatches calls to one of them through a pluggable loadbalancer.Picker.
+// Package pool maintains one gRPC connection per GreptimeDB endpoint and serves
+// the stubs created from it by address. Endpoint selection (load balancing and
+// health-aware failover) lives in the client, which drives this registry via
+// Addrs and Get.
 package pool
 
 import (
@@ -26,7 +28,6 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/GreptimeTeam/greptimedb-ingester-go/bulk"
-	"github.com/GreptimeTeam/greptimedb-ingester-go/loadbalancer"
 )
 
 // Endpoint bundles a gRPC connection with the stubs created from it. All
@@ -39,29 +40,24 @@ type Endpoint struct {
 	Bulk   *bulk.BulkClient
 }
 
-// Pool holds one Endpoint per address and dispatches Pick calls through the
-// configured Picker. Pool is safe for concurrent use.
+// Pool holds one Endpoint per address, addressable by Get. Pool is safe for
+// concurrent use: the endpoint map is built once in New and only read afterward.
 type Pool struct {
 	addrs     []string
 	endpoints map[string]*Endpoint
-	picker    loadbalancer.Picker
 }
 
 // New dials every address with the given dial options and returns a Pool.
 // grpc.NewClient is non-blocking: bad addresses surface as errors at the
-// first RPC, not here.
-func New(addrs []string, picker loadbalancer.Picker, dialOpts []grpc.DialOption) (*Pool, error) {
+// first RPC, not here. Duplicate addresses are de-duplicated.
+func New(addrs []string, dialOpts []grpc.DialOption) (*Pool, error) {
 	if len(addrs) == 0 {
 		return nil, errors.New("pool: at least one endpoint is required")
-	}
-	if picker == nil {
-		return nil, errors.New("pool: picker must not be nil")
 	}
 
 	p := &Pool{
 		addrs:     make([]string, 0, len(addrs)),
 		endpoints: make(map[string]*Endpoint, len(addrs)),
-		picker:    picker,
 	}
 
 	for _, addr := range addrs {
@@ -88,13 +84,10 @@ func New(addrs []string, picker loadbalancer.Picker, dialOpts []grpc.DialOption)
 	return p, nil
 }
 
-// Pick returns one Endpoint chosen by the configured picker. For a single
-// endpoint the picker is bypassed to avoid any per-call overhead.
-func (p *Pool) Pick() *Endpoint {
-	if len(p.addrs) == 1 {
-		return p.endpoints[p.addrs[0]]
-	}
-	return p.endpoints[p.picker.Pick(p.addrs)]
+// Get returns the Endpoint for addr, or nil if addr is not in the pool. Callers
+// pick addr from Addrs, so a nil result indicates a programming error.
+func (p *Pool) Get(addr string) *Endpoint {
+	return p.endpoints[addr]
 }
 
 // Addrs returns the list of endpoint addresses. The returned slice must not

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -28,8 +28,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
-
-	"github.com/GreptimeTeam/greptimedb-ingester-go/loadbalancer"
 )
 
 // fakeHealthServer counts HealthCheck invocations so tests can assert
@@ -74,7 +72,7 @@ func dialOpts() []grpc.DialOption {
 	return []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}
 }
 
-func TestPoolRoundRobinDispatch(t *testing.T) {
+func TestPoolGetReturnsWorkingEndpoint(t *testing.T) {
 	const n = 3
 	eps := make([]*fakeEndpoint, n)
 	addrs := make([]string, n)
@@ -88,74 +86,42 @@ func TestPoolRoundRobinDispatch(t *testing.T) {
 		}
 	}()
 
-	p, err := New(addrs, loadbalancer.NewRoundRobin(), dialOpts())
-	require.NoError(t, err)
-	defer func() { _ = p.Close() }()
-
-	const iters = 30
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	for i := 0; i < iters; i++ {
-		_, err := p.Pick().Health.HealthCheck(ctx, &gpb.HealthCheckRequest{})
-		require.NoError(t, err)
-	}
-
-	for i, e := range eps {
-		assert.Equal(t, uint64(iters/n), e.health.calls.Load(),
-			"endpoint %d (%s) call count", i, e.addr)
-	}
-}
-
-func TestPoolRandomHitsAllEndpoints(t *testing.T) {
-	const n = 3
-	eps := make([]*fakeEndpoint, n)
-	addrs := make([]string, n)
-	for i := 0; i < n; i++ {
-		eps[i] = startFakeEndpoint(t)
-		addrs[i] = eps[i].addr
-	}
-	defer func() {
-		for _, e := range eps {
-			e.stop()
-		}
-	}()
-
-	p, err := New(addrs, loadbalancer.NewRandom(), dialOpts())
+	p, err := New(addrs, dialOpts())
 	require.NoError(t, err)
 	defer func() { _ = p.Close() }()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	for i := 0; i < 300; i++ {
-		_, err := p.Pick().Health.HealthCheck(ctx, &gpb.HealthCheckRequest{})
+
+	// Each address resolves to its own backend: a call routed through Get(addr)
+	// must land on exactly that endpoint.
+	for i, addr := range addrs {
+		ep := p.Get(addr)
+		require.NotNil(t, ep)
+		assert.Equal(t, addr, ep.Addr)
+		_, err := ep.Health.HealthCheck(ctx, &gpb.HealthCheckRequest{})
 		require.NoError(t, err)
-	}
-	for i, e := range eps {
-		assert.Greater(t, e.health.calls.Load(), uint64(0),
-			"endpoint %d (%s) should have received at least one call", i, e.addr)
+		assert.Equal(t, uint64(1), eps[i].health.calls.Load(),
+			"only endpoint %d (%s) should have been called", i, addr)
 	}
 }
 
-func TestPoolSingleEndpointSkipsPicker(t *testing.T) {
+func TestPoolGetUnknownAddrReturnsNil(t *testing.T) {
 	ep := startFakeEndpoint(t)
 	defer ep.stop()
 
-	// Use a picker that would explode if called, proving the fast path bypass.
-	p, err := New([]string{ep.addr}, panicPicker{}, dialOpts())
+	p, err := New([]string{ep.addr}, dialOpts())
 	require.NoError(t, err)
 	defer func() { _ = p.Close() }()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-	_, err = p.Pick().Health.HealthCheck(ctx, &gpb.HealthCheckRequest{})
-	require.NoError(t, err)
+	assert.Nil(t, p.Get("127.0.0.1:1"))
 }
 
 func TestPoolDuplicateAddrsDeduplicated(t *testing.T) {
 	ep := startFakeEndpoint(t)
 	defer ep.stop()
 
-	p, err := New([]string{ep.addr, ep.addr, ep.addr}, loadbalancer.NewRoundRobin(), dialOpts())
+	p, err := New([]string{ep.addr, ep.addr, ep.addr}, dialOpts())
 	require.NoError(t, err)
 	defer func() { _ = p.Close() }()
 
@@ -163,12 +129,7 @@ func TestPoolDuplicateAddrsDeduplicated(t *testing.T) {
 }
 
 func TestPoolEmptyAddrsError(t *testing.T) {
-	_, err := New(nil, loadbalancer.NewRandom(), dialOpts())
-	assert.Error(t, err)
-}
-
-func TestPoolNilPickerError(t *testing.T) {
-	_, err := New([]string{"127.0.0.1:1"}, nil, dialOpts())
+	_, err := New(nil, dialOpts())
 	assert.Error(t, err)
 }
 
@@ -176,7 +137,7 @@ func TestPoolCloseIsIdempotent(t *testing.T) {
 	ep := startFakeEndpoint(t)
 	defer ep.stop()
 
-	p, err := New([]string{ep.addr}, loadbalancer.NewRandom(), dialOpts())
+	p, err := New([]string{ep.addr}, dialOpts())
 	require.NoError(t, err)
 
 	assert.NoError(t, p.Close())
@@ -185,7 +146,3 @@ func TestPoolCloseIsIdempotent(t *testing.T) {
 	// does not panic.
 	_ = p.Close()
 }
-
-type panicPicker struct{}
-
-func (panicPicker) Pick(_ []string) string { panic("picker should not be called for single endpoint") }

--- a/loadbalancer/selector.go
+++ b/loadbalancer/selector.go
@@ -21,14 +21,16 @@ import (
 	"time"
 )
 
-// Selector is an optional richer interface a Picker may implement. When the
-// configured Picker also satisfies Selector, the client passes the set of peers
-// already tried and failed in the current retry sequence via exclude so the
-// selector can steer away from them. Exclusion is best-effort: a selector must
-// fall open to the full set rather than fail when every endpoint is excluded,
-// because a retry against the least-bad peer beats no retry at all.
+// Selector picks one endpoint per call, honoring an exclude set so a retry loop
+// can steer away from peers already tried and failed in the current sequence.
+// Exclusion is best-effort: a selector must fall open to the full set rather
+// than fail when every endpoint is excluded, because a retry against the
+// least-bad peer beats no retry at all.
+//
+// A Picker that also implements Selector is used directly by the client;
+// otherwise AsSelector wraps it. NewOutlierDetector implements both Picker (so
+// it can be passed to Config.WithLoadBalancer) and Selector.
 type Selector interface {
-	Picker
 	Select(endpoints []string, exclude map[string]struct{}) string
 }
 
@@ -212,9 +214,14 @@ func (o *OutlierDetector) ReportFailure(endpoint string) {
 	// Only (re)eject when not already ejected, so failures observed during a
 	// fall-open window don't compound the back-off prematurely.
 	if h.consecutiveFailures >= o.threshold && !h.ejectedUntil.After(now) {
-		duration := o.baseEjection * time.Duration(1<<h.ejectionCount)
-		if duration <= 0 || duration > o.maxEjection { // <= 0 guards shift overflow
-			duration = o.maxEjection
+		// Window doubles per prior ejection, capped at maxEjection. ejectionCount
+		// never resets, so guard the shift against int64 overflow on a long-lived
+		// flapping endpoint: a too-large or wrapped value falls back to the cap.
+		duration := o.maxEjection
+		if h.ejectionCount < 63 {
+			if scaled := o.baseEjection << h.ejectionCount; scaled > 0 && scaled < o.maxEjection {
+				duration = scaled
+			}
 		}
 		h.ejectedUntil = now.Add(duration)
 		h.ejectionCount++

--- a/loadbalancer/selector.go
+++ b/loadbalancer/selector.go
@@ -1,0 +1,223 @@
+/*
+ * Copyright 2026 Greptime Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package loadbalancer
+
+import (
+	"sync"
+	"time"
+)
+
+// Selector is an optional richer interface a Picker may implement. When the
+// configured Picker also satisfies Selector, the client passes the set of peers
+// already tried and failed in the current retry sequence via exclude so the
+// selector can steer away from them. Exclusion is best-effort: a selector must
+// fall open to the full set rather than fail when every endpoint is excluded,
+// because a retry against the least-bad peer beats no retry at all.
+type Selector interface {
+	Picker
+	Select(endpoints []string, exclude map[string]struct{}) string
+}
+
+// HealthReporter is an optional interface a Picker may implement to learn
+// endpoint health from call outcomes. The client invokes ReportFailure on
+// transport-level endpoint failures and ReportSuccess when an endpoint answers
+// (including server business errors — the endpoint is alive and routing
+// correctly). A healthy frontend must never be ejected for a datanode-side
+// condition.
+type HealthReporter interface {
+	ReportSuccess(endpoint string)
+	ReportFailure(endpoint string)
+}
+
+// applyExclude drops excluded peers, falling open to the full list when that
+// would leave nothing to choose from.
+func applyExclude(endpoints []string, exclude map[string]struct{}) []string {
+	if len(exclude) == 0 {
+		return endpoints
+	}
+	kept := make([]string, 0, len(endpoints))
+	for _, ep := range endpoints {
+		if _, skip := exclude[ep]; !skip {
+			kept = append(kept, ep)
+		}
+	}
+	if len(kept) == 0 {
+		return endpoints
+	}
+	return kept
+}
+
+// AsSelector adapts a Picker into a Selector. A Picker that already implements
+// Selector is returned unchanged; otherwise it is wrapped so exclude is honored
+// by pre-filtering the candidate list before delegating to Pick.
+func AsSelector(p Picker) Selector {
+	if s, ok := p.(Selector); ok {
+		return s
+	}
+	return pickerSelector{p}
+}
+
+type pickerSelector struct{ Picker }
+
+func (s pickerSelector) Select(endpoints []string, exclude map[string]struct{}) string {
+	return s.Pick(applyExclude(endpoints, exclude))
+}
+
+// OutlierDetectorOptions configures NewOutlierDetector. Zero-value fields take
+// the documented defaults.
+type OutlierDetectorOptions struct {
+	// Base chooses among the currently-healthy peers. Defaults to NewRandom().
+	Base Picker
+	// ConsecutiveFailures is the number of back-to-back endpoint failures
+	// before an endpoint is ejected from selection. Defaults to 5.
+	ConsecutiveFailures int
+	// BaseEjection is the first ejection duration; it doubles on each
+	// re-ejection up to MaxEjection. Defaults to 30s.
+	BaseEjection time.Duration
+	// MaxEjection caps a single ejection duration. Defaults to 300s.
+	MaxEjection time.Duration
+
+	// now is an injectable clock for tests. Defaults to time.Now.
+	now func() time.Time
+}
+
+type endpointHealth struct {
+	consecutiveFailures int
+	ejectedUntil        time.Time
+	ejectionCount       int
+}
+
+// OutlierDetector wraps a base Picker and removes endpoints that fail
+// ConsecutiveFailures times in a row from the candidate set for a back-off
+// window. Health is fed by ReportSuccess / ReportFailure from call outcomes.
+// Ejection is time-based and re-admission is lazy (checked against the clock at
+// Select time, no background timers). If every endpoint is ejected it falls
+// open to the full set so writes never hard-stall on a transient cluster-wide
+// failure. Safe for concurrent use.
+//
+// A stateful detector instance keys health by endpoint address and must not be
+// shared across clients configured with different endpoint sets.
+type OutlierDetector struct {
+	base         Picker
+	threshold    int
+	baseEjection time.Duration
+	maxEjection  time.Duration
+	now          func() time.Time
+
+	mu     sync.Mutex
+	health map[string]*endpointHealth
+}
+
+// NewOutlierDetector returns a health-aware Selector with Envoy-style
+// consecutive-failure outlier ejection.
+func NewOutlierDetector(opts OutlierDetectorOptions) *OutlierDetector {
+	base := opts.Base
+	if base == nil {
+		base = NewRandom()
+	}
+	threshold := opts.ConsecutiveFailures
+	if threshold < 1 {
+		threshold = 5
+	}
+	baseEjection := opts.BaseEjection
+	if baseEjection <= 0 {
+		baseEjection = 30 * time.Second
+	}
+	maxEjection := opts.MaxEjection
+	if maxEjection <= 0 {
+		maxEjection = 300 * time.Second
+	}
+	now := opts.now
+	if now == nil {
+		now = time.Now
+	}
+	return &OutlierDetector{
+		base:         base,
+		threshold:    threshold,
+		baseEjection: baseEjection,
+		maxEjection:  maxEjection,
+		now:          now,
+		health:       make(map[string]*endpointHealth),
+	}
+}
+
+// Pick selects among the currently-healthy endpoints without exclusion.
+func (o *OutlierDetector) Pick(endpoints []string) string {
+	return o.Select(endpoints, nil)
+}
+
+// Select returns a healthy, non-excluded endpoint chosen by the base picker.
+func (o *OutlierDetector) Select(endpoints []string, exclude map[string]struct{}) string {
+	now := o.now()
+
+	o.mu.Lock()
+	healthy := make([]string, 0, len(endpoints))
+	for _, ep := range endpoints {
+		h := o.health[ep]
+		if h == nil || !h.ejectedUntil.After(now) {
+			healthy = append(healthy, ep)
+		}
+	}
+	o.mu.Unlock()
+
+	candidates := healthy
+	if len(candidates) == 0 {
+		candidates = endpoints
+	}
+	return o.base.Pick(applyExclude(candidates, exclude))
+}
+
+// ReportSuccess clears any failure streak for endpoint and re-admits it.
+func (o *OutlierDetector) ReportSuccess(endpoint string) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	if h := o.health[endpoint]; h != nil {
+		// A fresh success outweighs stale failures: clear the streak and
+		// re-admit immediately. During an active ejection the endpoint is not
+		// selected, so a success can only arrive via a fall-open window —
+		// exactly when we want to re-admit the one peer that works.
+		h.consecutiveFailures = 0
+		h.ejectedUntil = time.Time{}
+	}
+}
+
+// ReportFailure records a transport-level failure for endpoint and ejects it
+// once the consecutive-failure threshold is crossed.
+func (o *OutlierDetector) ReportFailure(endpoint string) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	h := o.health[endpoint]
+	if h == nil {
+		h = &endpointHealth{}
+		o.health[endpoint] = h
+	}
+	h.consecutiveFailures++
+
+	now := o.now()
+	// Only (re)eject when not already ejected, so failures observed during a
+	// fall-open window don't compound the back-off prematurely.
+	if h.consecutiveFailures >= o.threshold && !h.ejectedUntil.After(now) {
+		duration := o.baseEjection * time.Duration(1<<h.ejectionCount)
+		if duration <= 0 || duration > o.maxEjection { // <= 0 guards shift overflow
+			duration = o.maxEjection
+		}
+		h.ejectedUntil = now.Add(duration)
+		h.ejectionCount++
+		h.consecutiveFailures = 0
+	}
+}

--- a/loadbalancer/selector.go
+++ b/loadbalancer/selector.go
@@ -48,6 +48,14 @@ type HealthReporter interface {
 // applyExclude drops excluded peers, falling open to the full list when that
 // would leave nothing to choose from.
 func applyExclude(endpoints []string, exclude map[string]struct{}) []string {
+	kept := excludeEndpoints(endpoints, exclude)
+	if len(kept) == 0 {
+		return endpoints
+	}
+	return kept
+}
+
+func excludeEndpoints(endpoints []string, exclude map[string]struct{}) []string {
 	if len(exclude) == 0 {
 		return endpoints
 	}
@@ -56,9 +64,6 @@ func applyExclude(endpoints []string, exclude map[string]struct{}) []string {
 		if _, skip := exclude[ep]; !skip {
 			kept = append(kept, ep)
 		}
-	}
-	if len(kept) == 0 {
-		return endpoints
 	}
 	return kept
 }
@@ -179,8 +184,16 @@ func (o *OutlierDetector) Select(endpoints []string, exclude map[string]struct{}
 	candidates := healthy
 	if len(candidates) == 0 {
 		candidates = endpoints
+	} else if filtered := excludeEndpoints(candidates, exclude); len(filtered) > 0 {
+		candidates = filtered
+	} else {
+		// Every healthy endpoint has already failed in this retry sequence.
+		// Widen to the full endpoint set, still honoring the per-call exclude
+		// set when possible, so an ejected peer gets a chance before we retry
+		// the same failed healthy endpoint.
+		candidates = applyExclude(endpoints, exclude)
 	}
-	return o.base.Pick(applyExclude(candidates, exclude))
+	return o.base.Pick(candidates)
 }
 
 // ReportSuccess clears any failure streak for endpoint and re-admits it.

--- a/loadbalancer/selector_test.go
+++ b/loadbalancer/selector_test.go
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2026 Greptime Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package loadbalancer
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyExcludeFallsOpenWhenAllExcluded(t *testing.T) {
+	eps := []string{"a", "b"}
+	assert.Equal(t, eps, applyExclude(eps, nil))
+	assert.Equal(t, []string{"b"}, applyExclude(eps, map[string]struct{}{"a": {}}))
+	// Everything excluded → fall open to the full list.
+	assert.Equal(t, eps, applyExclude(eps, map[string]struct{}{"a": {}, "b": {}}))
+}
+
+func TestAsSelectorWrapsPlainPicker(t *testing.T) {
+	// RoundRobin is a plain Picker; the adapter must honor exclude.
+	s := AsSelector(NewRoundRobin())
+	got := s.Select([]string{"a", "b"}, map[string]struct{}{"a": {}})
+	assert.Equal(t, "b", got)
+}
+
+func TestAsSelectorPassesThroughExistingSelector(t *testing.T) {
+	od := NewOutlierDetector(OutlierDetectorOptions{})
+	assert.Same(t, od, AsSelector(od))
+}
+
+// fixedClock is a controllable monotonic clock for deterministic ejection tests.
+type fixedClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func (c *fixedClock) advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.now = c.now.Add(d)
+}
+
+func (c *fixedClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func newTestDetector(clk *fixedClock, opts OutlierDetectorOptions) *OutlierDetector {
+	opts.now = clk.Now
+	return NewOutlierDetector(opts)
+}
+
+func TestOutlierDetectorEjectsAfterConsecutiveFailures(t *testing.T) {
+	clk := &fixedClock{now: time.Unix(0, 0)}
+	od := newTestDetector(clk, OutlierDetectorOptions{
+		Base:                NewRoundRobin(),
+		ConsecutiveFailures: 3,
+		BaseEjection:        30 * time.Second,
+	})
+	eps := []string{"a", "b"}
+
+	// Two failures: below threshold, still selectable.
+	od.ReportFailure("a")
+	od.ReportFailure("a")
+	assert.Contains(t, candidatesOver(od, eps, 20), "a")
+
+	// Third failure crosses the threshold → "a" is ejected.
+	od.ReportFailure("a")
+	picks := candidatesOver(od, eps, 20)
+	assert.NotContains(t, picks, "a", "ejected endpoint must not be selected")
+	assert.Contains(t, picks, "b")
+}
+
+func TestOutlierDetectorReadmitsAfterEjectionWindow(t *testing.T) {
+	clk := &fixedClock{now: time.Unix(0, 0)}
+	od := newTestDetector(clk, OutlierDetectorOptions{
+		ConsecutiveFailures: 1,
+		BaseEjection:        30 * time.Second,
+	})
+	eps := []string{"a", "b"}
+
+	od.ReportFailure("a")
+	assert.NotContains(t, candidatesOver(od, eps, 20), "a")
+
+	// Before the window expires, still ejected.
+	clk.advance(29 * time.Second)
+	assert.NotContains(t, candidatesOver(od, eps, 20), "a")
+
+	// After the window, re-admitted (lazy, no timers).
+	clk.advance(2 * time.Second)
+	assert.Contains(t, candidatesOver(od, eps, 20), "a")
+}
+
+func TestOutlierDetectorBackoffDoubles(t *testing.T) {
+	clk := &fixedClock{now: time.Unix(0, 0)}
+	od := newTestDetector(clk, OutlierDetectorOptions{
+		ConsecutiveFailures: 1,
+		BaseEjection:        10 * time.Second,
+		MaxEjection:         60 * time.Second,
+	})
+	eps := []string{"a", "b"}
+
+	// First ejection: 10s window.
+	od.ReportFailure("a")
+	clk.advance(11 * time.Second) // expires
+	assert.Contains(t, candidatesOver(od, eps, 20), "a")
+
+	// Second ejection should last 20s (doubled).
+	od.ReportFailure("a")
+	clk.advance(11 * time.Second)
+	assert.NotContains(t, candidatesOver(od, eps, 20), "a", "second ejection must be longer than 10s")
+	clk.advance(10 * time.Second) // now past 20s total
+	assert.Contains(t, candidatesOver(od, eps, 20), "a")
+}
+
+func TestOutlierDetectorSuccessResetsStreak(t *testing.T) {
+	clk := &fixedClock{now: time.Unix(0, 0)}
+	od := newTestDetector(clk, OutlierDetectorOptions{ConsecutiveFailures: 3})
+	eps := []string{"a", "b"}
+
+	od.ReportFailure("a")
+	od.ReportFailure("a")
+	od.ReportSuccess("a") // resets streak
+	od.ReportFailure("a")
+	od.ReportFailure("a")
+	// Only two consecutive failures since the reset: not yet ejected.
+	assert.Contains(t, candidatesOver(od, eps, 20), "a")
+}
+
+func TestOutlierDetectorFallsOpenWhenAllEjected(t *testing.T) {
+	clk := &fixedClock{now: time.Unix(0, 0)}
+	od := newTestDetector(clk, OutlierDetectorOptions{ConsecutiveFailures: 1})
+	eps := []string{"a", "b"}
+
+	od.ReportFailure("a")
+	od.ReportFailure("b")
+	// Both ejected → fall open so writes never hard-stall.
+	got := od.Select(eps, nil)
+	assert.Contains(t, eps, got)
+}
+
+func TestOutlierDetectorExcludeStillHonored(t *testing.T) {
+	clk := &fixedClock{now: time.Unix(0, 0)}
+	od := newTestDetector(clk, OutlierDetectorOptions{Base: NewRoundRobin(), ConsecutiveFailures: 5})
+	// No ejections; exclude "a" should steer to "b".
+	got := od.Select([]string{"a", "b"}, map[string]struct{}{"a": {}})
+	assert.Equal(t, "b", got)
+}
+
+func TestNewOutlierDetectorDefaults(t *testing.T) {
+	od := NewOutlierDetector(OutlierDetectorOptions{})
+	assert.Equal(t, 5, od.threshold)
+	assert.Equal(t, 30*time.Second, od.baseEjection)
+	assert.Equal(t, 300*time.Second, od.maxEjection)
+	require.NotNil(t, od.base)
+	require.NotNil(t, od.now)
+}
+
+// candidatesOver samples Select n times and returns the set of distinct peers
+// chosen, so a test can assert whether an ejected endpoint ever appears.
+func candidatesOver(od *OutlierDetector, eps []string, n int) map[string]struct{} {
+	seen := make(map[string]struct{})
+	for i := 0; i < n; i++ {
+		seen[od.Select(eps, nil)] = struct{}{}
+	}
+	return seen
+}

--- a/loadbalancer/selector_test.go
+++ b/loadbalancer/selector_test.go
@@ -131,6 +131,32 @@ func TestOutlierDetectorBackoffDoubles(t *testing.T) {
 	assert.Contains(t, candidatesOver(od, eps, 20), "a")
 }
 
+func TestOutlierDetectorBackoffNeverWrapsOnManyEjections(t *testing.T) {
+	clk := &fixedClock{now: time.Unix(0, 0)}
+	od := newTestDetector(clk, OutlierDetectorOptions{
+		ConsecutiveFailures: 1,
+		BaseEjection:        30 * time.Second,
+		MaxEjection:         300 * time.Second,
+	})
+	eps := []string{"a", "b"}
+
+	// Re-eject "a" many times; ejectionCount climbs well past the int64 shift
+	// width. Each window must stay within (0, maxEjection] — never wrap to a
+	// short or negative window.
+	for i := 0; i < 70; i++ {
+		od.ReportFailure("a")
+		od.mu.Lock()
+		h := od.health["a"]
+		window := h.ejectedUntil.Sub(clk.Now())
+		od.mu.Unlock()
+		assert.Greater(t, window, time.Duration(0), "ejection %d window must be positive", i)
+		assert.LessOrEqual(t, window, 300*time.Second, "ejection %d window must not exceed maxEjection", i)
+		// Expire the window so the next ReportFailure re-ejects.
+		clk.advance(window + time.Second)
+		_ = candidatesOver(od, eps, 1) // lazy re-admission check
+	}
+}
+
 func TestOutlierDetectorSuccessResetsStreak(t *testing.T) {
 	clk := &fixedClock{now: time.Unix(0, 0)}
 	od := newTestDetector(clk, OutlierDetectorOptions{ConsecutiveFailures: 3})

--- a/loadbalancer/selector_test.go
+++ b/loadbalancer/selector_test.go
@@ -191,6 +191,23 @@ func TestOutlierDetectorExcludeStillHonored(t *testing.T) {
 	assert.Equal(t, "b", got)
 }
 
+func TestOutlierDetectorWidensWhenHealthyCandidatesExcluded(t *testing.T) {
+	clk := &fixedClock{now: time.Unix(0, 0)}
+	od := newTestDetector(clk, OutlierDetectorOptions{
+		Base:                NewRoundRobin(),
+		ConsecutiveFailures: 1,
+		BaseEjection:        time.Hour,
+	})
+	eps := []string{"a", "b"}
+
+	od.ReportFailure("b")
+	assert.NotContains(t, candidatesOver(od, eps, 20), "b")
+
+	got := od.Select(eps, map[string]struct{}{"a": {}})
+	assert.Equal(t, "b", got,
+		"when all healthy peers are excluded by the retry sequence, try an ejected peer before reusing the failed one")
+}
+
 func TestNewOutlierDetectorDefaults(t *testing.T) {
 	od := NewOutlierDetector(OutlierDetectorOptions{})
 	assert.Equal(t, 5, od.threshold)


### PR DESCRIPTION
## Summary

Close #103 

- add unary failover retry across configured endpoints
- add health-aware outlier ejection for endpoint selection
- document retry and failover behavior

## Tests
- go test ./loadbalancer
- go test .
- go test ./internal/pool
- go test ./...
- go build ./...
- make lint