### PR TITLE
feat: enable gRPC keepalive by default

### DIFF
--- a/config.go
+++ b/config.go
@@ -128,18 +128,15 @@ func (c *Config) WithAuth(username, password string) *Config {
 	return c
 }
 
-// WithKeepalive overrides the keepalive option. Keepalive is enabled by
-// default (30s ping interval, 10s timeout); call this only to tune it, or
-// WithoutKeepalive to turn it off.
-//   - time. After a duration of this time if the client doesn't see any activity it
-//     pings the server to see if the transport is still alive.
-//     If set below 10s, a minimum value of 10s will be used instead.
-//   - timeout. After having pinged for keepalive check, the client waits for a duration
-//     of Timeout and if no activity is seen even after that the connection is closed.
+// WithKeepalive overrides the default keepalive (30s interval, 10s timeout);
+// use WithoutKeepalive to turn it off.
+//   - interval: idle duration before the client pings to check liveness. gRPC
+//     clamps this to a 10s minimum.
+//   - timeout: how long to wait for a ping ack before closing the connection.
 //
-// A zero time or timeout falls back to the corresponding default.
-func (c *Config) WithKeepalive(time, timeout time.Duration) *Config {
-	keepalive := options.NewKeepaliveOption(time, timeout)
+// A zero interval or timeout falls back to the default.
+func (c *Config) WithKeepalive(interval, timeout time.Duration) *Config {
+	keepalive := options.NewKeepaliveOption(interval, timeout)
 	c.keepalive = &keepalive
 	return c
 }
@@ -255,7 +252,7 @@ func (c *Config) build() []grpc.DialOption {
 		c.tls = &opt
 	}
 
-	// Copy to keep build idempotent and non-mutating.
+	// Copy so repeated builds don't append onto the caller's slice.
 	opts := append([]grpc.DialOption(nil), c.options...)
 	if c.keepalive != nil {
 		opts = append(opts, c.keepalive.Build())

--- a/config.go
+++ b/config.go
@@ -63,6 +63,9 @@ type Config struct {
 	tls     *options.TlsOption
 	options []grpc.DialOption
 
+	// keepalive holds the gRPC keepalive params; nil disables keepalive.
+	keepalive *options.KeepaliveOption
+
 	telemetry *options.TelemetryOptions
 }
 
@@ -76,9 +79,11 @@ type Config struct {
 //   - NewConfig("host1:4001", "host2:4001", ...) — equivalent to
 //     NewConfig().WithEndpoints(args...). WithPort has no effect.
 func NewConfig(hosts ...string) *Config {
+	defaultKeepalive := options.DefaultKeepaliveOption()
 	cfg := &Config{
 		Port: 4001,
 
+		keepalive: &defaultKeepalive,
 		telemetry: options.NewTelemetryOptions(),
 		options: []grpc.DialOption{
 			options.NewUserAgentOption(version).Build(),
@@ -123,15 +128,25 @@ func (c *Config) WithAuth(username, password string) *Config {
 	return c
 }
 
-// WithKeepalive helps to set the keepalive option.
+// WithKeepalive overrides the keepalive option. Keepalive is enabled by
+// default (30s ping interval, 10s timeout); call this only to tune it, or
+// WithoutKeepalive to turn it off.
 //   - time. After a duration of this time if the client doesn't see any activity it
 //     pings the server to see if the transport is still alive.
 //     If set below 10s, a minimum value of 10s will be used instead.
 //   - timeout. After having pinged for keepalive check, the client waits for a duration
 //     of Timeout and if no activity is seen even after that the connection is closed.
+//
+// A zero time or timeout falls back to the corresponding default.
 func (c *Config) WithKeepalive(time, timeout time.Duration) *Config {
-	keepalive := options.NewKeepaliveOption(time, timeout).Build()
-	c.options = append(c.options, keepalive)
+	keepalive := options.NewKeepaliveOption(time, timeout)
+	c.keepalive = &keepalive
+	return c
+}
+
+// WithoutKeepalive disables gRPC keepalive pings, which are enabled by default.
+func (c *Config) WithoutKeepalive() *Config {
+	c.keepalive = nil
 	return c
 }
 
@@ -240,6 +255,11 @@ func (c *Config) build() []grpc.DialOption {
 		c.tls = &opt
 	}
 
-	c.options = append(c.options, c.tls.Build(), c.telemetry.Build())
-	return c.options
+	// Copy to keep build idempotent and non-mutating.
+	opts := append([]grpc.DialOption(nil), c.options...)
+	if c.keepalive != nil {
+		opts = append(opts, c.keepalive.Build())
+	}
+	opts = append(opts, c.tls.Build(), c.telemetry.Build())
+	return opts
 }

--- a/config_test.go
+++ b/config_test.go
@@ -18,6 +18,7 @@ package greptime
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -119,6 +120,24 @@ func TestNewClientInvalidEndpoint(t *testing.T) {
 	_, err := NewClient(NewConfig().WithEndpoints("missing-port"))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid endpoint")
+}
+
+func TestKeepaliveEnabledByDefault(t *testing.T) {
+	cfg := NewConfig("127.0.0.1:4001")
+	require.NotNil(t, cfg.keepalive, "keepalive should be on by default")
+
+	withKA := len(cfg.build())
+	cfg.WithoutKeepalive()
+	assert.Nil(t, cfg.keepalive)
+	assert.Equal(t, withKA-1, len(cfg.build()), "disabling keepalive drops exactly one dial option")
+}
+
+func TestWithKeepaliveReplacesNotAppends(t *testing.T) {
+	base := len(NewConfig("127.0.0.1:4001").build())
+	cfg := NewConfig("127.0.0.1:4001").WithKeepalive(time.Minute, 20*time.Second)
+	require.NotNil(t, cfg.keepalive)
+	assert.Equal(t, base, len(cfg.build()),
+		"WithKeepalive replaces the default rather than appending a second option")
 }
 
 func TestNewClientWithoutPickerLeavesCfgUntouched(t *testing.T) {

--- a/options/keepalive.go
+++ b/options/keepalive.go
@@ -25,8 +25,13 @@ import (
 
 var (
 	defaultKeepaliveTime    = time.Second * 30
-	defaultKeepaliveTimeout = time.Second * 5
+	defaultKeepaliveTimeout = time.Second * 10
 )
+
+// DefaultKeepaliveOption is the keepalive applied when none is set explicitly.
+func DefaultKeepaliveOption() KeepaliveOption {
+	return NewKeepaliveOption(defaultKeepaliveTime, defaultKeepaliveTimeout)
+}
 
 type KeepaliveOption struct {
 	time    time.Duration


### PR DESCRIPTION
## What

gRPC keepalive was opt-in via `Config.WithKeepalive`. This makes it **on by default**:

- **Interval** 30s, **timeout** 10s, `PermitWithoutStream: true`.
- New `Config.WithoutKeepalive()` to opt out.
- Keepalive is now held as a `Config` field and built once, so `WithKeepalive` **replaces** the default instead of appending a second `WithKeepaliveParams`.

Applies uniformly to unary (`Write`/`Delete`), streaming (`StreamWrite`/`StreamDelete`) and `BulkWrite` — they all share one `grpc.ClientConn` per endpoint.

## Why

Without keepalive, an idle connection behind an LB / NAT / firewall can be silently dropped and only surface as an error at the next write. Idle streaming sessions are the worst case. Default-on pings probe liveness and let the existing failover steer away from dead endpoints sooner.

Default-on is safe here: GreptimeDB's frontend gRPC server is tonic, which enforces no minimum ping interval (no grpc-go-style `too_many_pings` GOAWAY). 30s also matches GreptimeDB's own internal gRPC client default.

## Values

- `timeout` bumped from the previous 5s default to **10s** to avoid false disconnects under a GC pause or network jitter over public networks.
- A zero `time`/`timeout` passed to `WithKeepalive` still falls back to the defaults.

## Test

- `TestKeepaliveEnabledByDefault` — default-on, and `WithoutKeepalive` drops exactly one dial option.
- `TestWithKeepaliveReplacesNotAppends` — override replaces rather than appends.
- Full `go test ./...` green.