### PR TITLE
feat: support auto-create table metadata for bulk writer

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,13 @@ endpoint until `CloseStream`; if it fails mid-stream the `Send` returns the
 error and the next `StreamWrite` picks a fresh endpoint. Both feed the load
 balancer's health state so a failed endpoint is avoided on the next pick.
 
+**Auto-create.** When the target table does not exist yet, GreptimeDB
+Enterprise can create it from the column metadata attached to the Arrow schema
+of a bulk write. Pass `bulk.WithAutoCreateSchema` to `BulkWriteWithOptions` (or
+to `bulk.BulkClient.NewBulkWriter`) to declare each column's semantic type
+(`tag`, `field` or `timestamp`) and optional comment. See
+[examples/bulkwrite](examples/bulkwrite/README.md) for a full example.
+
 ### Client
 
 ```go

--- a/README.md
+++ b/README.md
@@ -128,7 +128,13 @@ balancer's health state so a failed endpoint is avoided on the next pick.
 Enterprise can create it from the column metadata attached to the Arrow schema
 of a bulk write. Pass `bulk.WithAutoCreateSchema` to `BulkWriteWithOptions` (or
 to `bulk.BulkClient.NewBulkWriter`) to declare each column's semantic type
-(`tag`, `field` or `timestamp`) and optional comment. See
+(`tag`, `field` or `timestamp`) and optional comment. The option also sends the
+`auto_create_table=true` Flight request hint before opening the stream. The
+server must have Flight bulk auto-create enabled globally; the request hint
+cannot override a disabled server setting. The schema must contain exactly one
+timezone-free timestamp column; JSON is encoded
+as Arrow Binary with `greptime:type=Json`, while Vector auto-create is not
+supported. See
 [examples/bulkwrite](examples/bulkwrite/README.md) for a full example.
 
 ### Client

--- a/bulk/autocreate.go
+++ b/bulk/autocreate.go
@@ -17,13 +17,16 @@
 package bulk
 
 import (
+	"context"
 	"fmt"
 	"maps"
 	"slices"
+	"strings"
 
 	gpbv1 "github.com/GreptimeTeam/greptime-proto/go/greptime/v1"
 	"github.com/apache/arrow/go/v17/arrow"
 	"github.com/apache/arrow/go/v17/arrow/array"
+	"google.golang.org/grpc/metadata"
 
 	"github.com/GreptimeTeam/greptimedb-ingester-go/util"
 )
@@ -31,6 +34,9 @@ import (
 // Arrow field metadata keys recognized by GreptimeDB Enterprise when
 // auto-creating a missing table for a Flight bulk insert.
 const (
+	autoCreateTableHintKey      = "auto_create_table"
+	autoCreateTableHintMetadata = "x-greptime-hint-auto_create_table"
+	hintsMetadataKey            = "x-greptime-hints"
 	// semanticTypeMetadataKey carries the semantic type of a column. The value
 	// must be "tag", "field" or "timestamp"; exactly one "timestamp" column
 	// becomes the time index of the created table.
@@ -41,6 +47,34 @@ const (
 	// commentMetadataKey carries the column comment.
 	commentMetadataKey = "greptime:comment"
 )
+
+func withAutoCreateTableHint(ctx context.Context) context.Context {
+	md, _ := metadata.FromOutgoingContext(ctx)
+	md = md.Copy()
+
+	if values := md.Get(hintsMetadataKey); len(values) > 0 {
+		md.Set(hintsMetadataKey, upsertAutoCreateTableHint(strings.Join(values, ",")))
+	} else {
+		md.Set(autoCreateTableHintMetadata, "true")
+	}
+	return metadata.NewOutgoingContext(ctx, md)
+}
+
+func upsertAutoCreateTableHint(hints string) string {
+	parts := strings.Split(hints, ",")
+	found := false
+	for i, hint := range parts {
+		key, _, ok := strings.Cut(hint, "=")
+		if ok && strings.TrimSpace(key) == autoCreateTableHintKey {
+			parts[i] = autoCreateTableHintKey + "=true"
+			found = true
+		}
+	}
+	if !found {
+		parts = append(parts, autoCreateTableHintKey+"=true")
+	}
+	return strings.Join(parts, ",")
+}
 
 // AutoCreateColumn describes the schema metadata of a single column needed by
 // GreptimeDB Enterprise to auto-create a missing table during a Flight bulk
@@ -58,9 +92,9 @@ type AutoCreateColumn struct {
 	// Comment is an optional column comment, carried as greptime:comment.
 	Comment string
 	// TypeOverride is an optional GreptimeDB extended data type, carried as
-	// greptime:type, for example "Json". JSON columns are auto-detected from
-	// the written table's schema, so it only needs to be set for columns whose
-	// extended type cannot be inferred from the Arrow type.
+	// greptime:type. Flight bulk auto-create currently supports only "Json",
+	// and the Arrow field must be Binary. JSON columns are auto-detected from
+	// the written table's schema.
 	TypeOverride string
 
 	// semanticType overrides the semantic type declared by the written table's
@@ -97,9 +131,9 @@ type AutoCreateSchema struct {
 	Columns []AutoCreateColumn
 }
 
-// WithAutoCreateSchema configures the bulk writer to attach the given column
-// metadata to the Arrow schema of every written record batch, so that
-// GreptimeDB Enterprise can auto-create the table if it does not exist yet.
+// WithAutoCreateSchema configures the bulk writer to request table auto-create
+// before opening the Flight stream and attach the given column metadata to its
+// Arrow schema, so GreptimeDB Enterprise can create the table if it is missing.
 func WithAutoCreateSchema(schema *AutoCreateSchema) WriterOption {
 	return func(bw *bulkWriter) {
 		bw.autoCreate = schema
@@ -164,11 +198,15 @@ func applyAutoCreateMetadata(
 
 	tableByName := make(map[string]*gpbv1.ColumnSchema, len(columns))
 	for _, col := range columns {
+		if _, duplicate := tableByName[col.ColumnName]; duplicate {
+			return nil, fmt.Errorf("duplicate written column %q", col.ColumnName)
+		}
 		tableByName[col.ColumnName] = col
 	}
 
 	fields := rec.Schema().Fields()
 	enriched := make([]arrow.Field, len(fields))
+	timestampCount := 0
 	for i, field := range fields {
 		enriched[i] = field
 		specCol, inSpec := lookup(field.Name)
@@ -181,20 +219,49 @@ func applyAutoCreateMetadata(
 		if !ok {
 			continue
 		}
-		if semanticType == gpbv1.SemanticType_TIMESTAMP && specCol.TypeOverride != "" {
-			return nil, fmt.Errorf(
-				"column %q is a timestamp and cannot carry a type override",
-				field.Name,
-			)
+		semanticTypeValue, ok := semanticTypeString(semanticType)
+		if !ok {
+			return nil, fmt.Errorf("column %q has unsupported semantic type %d", field.Name, semanticType)
+		}
+		if semanticType == gpbv1.SemanticType_TIMESTAMP {
+			timestampCount++
+			timestampType, ok := field.Type.(*arrow.TimestampType)
+			if !ok || timestampType.TimeZone != "" {
+				return nil, fmt.Errorf(
+					"timestamp column %q must have Arrow timestamp type without timezone",
+					field.Name,
+				)
+			}
+			if specCol.TypeOverride != "" {
+				return nil, fmt.Errorf(
+					"column %q is a timestamp and cannot carry a type override",
+					field.Name,
+				)
+			}
 		}
 
 		metadata := map[string]string{
-			semanticTypeMetadataKey: semanticTypeString(semanticType),
+			semanticTypeMetadataKey: semanticTypeValue,
 		}
-		if specCol.TypeOverride != "" {
-			metadata[typeMetadataKey] = specCol.TypeOverride
-		} else if inTable && tableCol.Datatype == gpbv1.ColumnDataType_JSON {
-			metadata[typeMetadataKey] = "Json"
+		typeOverride := specCol.TypeOverride
+		if typeOverride == "" && inTable && tableCol.Datatype == gpbv1.ColumnDataType_JSON &&
+			semanticType != gpbv1.SemanticType_TIMESTAMP {
+			typeOverride = "Json"
+		}
+		if typeOverride != "" {
+			if typeOverride != "Json" {
+				return nil, fmt.Errorf(
+					"column %q has unsupported type override %q; only Json is supported",
+					field.Name, typeOverride,
+				)
+			}
+			if !arrow.TypeEqual(field.Type, arrow.BinaryTypes.Binary) {
+				return nil, fmt.Errorf(
+					"column %q with Json type override requires Arrow Binary type, got %s",
+					field.Name, field.Type,
+				)
+			}
+			metadata[typeMetadataKey] = typeOverride
 		}
 		if specCol.Comment != "" {
 			metadata[commentMetadataKey] = specCol.Comment
@@ -218,6 +285,12 @@ func applyAutoCreateMetadata(
 			slices.Sorted(maps.Keys(exactByName)),
 		)
 	}
+	if timestampCount != 1 {
+		return nil, fmt.Errorf(
+			"auto-create schema must contain exactly one timestamp column, got %d",
+			timestampCount,
+		)
+	}
 
 	metadata := rec.Schema().Metadata()
 	return array.NewRecord(arrow.NewSchema(enriched, &metadata), rec.Columns(), rec.NumRows()), nil
@@ -237,15 +310,15 @@ func columnSemanticType(
 	return gpbv1.SemanticType_TAG, false
 }
 
-func semanticTypeString(t gpbv1.SemanticType) string {
+func semanticTypeString(t gpbv1.SemanticType) (string, bool) {
 	switch t {
 	case gpbv1.SemanticType_TAG:
-		return "tag"
+		return "tag", true
 	case gpbv1.SemanticType_FIELD:
-		return "field"
+		return "field", true
 	case gpbv1.SemanticType_TIMESTAMP:
-		return "timestamp"
+		return "timestamp", true
 	default:
-		return ""
+		return "", false
 	}
 }

--- a/bulk/autocreate.go
+++ b/bulk/autocreate.go
@@ -1,0 +1,251 @@
+/*
+ * Copyright 2026 Greptime Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package bulk
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+
+	gpbv1 "github.com/GreptimeTeam/greptime-proto/go/greptime/v1"
+	"github.com/apache/arrow/go/v17/arrow"
+	"github.com/apache/arrow/go/v17/arrow/array"
+
+	"github.com/GreptimeTeam/greptimedb-ingester-go/util"
+)
+
+// Arrow field metadata keys recognized by GreptimeDB Enterprise when
+// auto-creating a missing table for a Flight bulk insert.
+const (
+	// semanticTypeMetadataKey carries the semantic type of a column. The value
+	// must be "tag", "field" or "timestamp"; exactly one "timestamp" column
+	// becomes the time index of the created table.
+	semanticTypeMetadataKey = "greptime:semantic_type"
+	// typeMetadataKey carries the GreptimeDB extended data type of a column,
+	// e.g. "Json" for a JSON column.
+	typeMetadataKey = "greptime:type"
+	// commentMetadataKey carries the column comment.
+	commentMetadataKey = "greptime:comment"
+)
+
+// AutoCreateColumn describes the schema metadata of a single column needed by
+// GreptimeDB Enterprise to auto-create a missing table during a Flight bulk
+// insert. The metadata is attached to the Arrow schema of every written record
+// batch and matched to columns by (sanitized) name.
+//
+// The semantic type defaults to the one declared by the written table's schema.
+// Use TagColumn, FieldColumn or TimestampColumn to override it, and a plain
+// struct literal to only attach a comment or a type override.
+type AutoCreateColumn struct {
+	// Name is the column name. It matches a written column by exact name first,
+	// then by sanitized name, so it works with both sanitized and unsanitized
+	// tables (see table.Table.WithSanitate).
+	Name string
+	// Comment is an optional column comment, carried as greptime:comment.
+	Comment string
+	// TypeOverride is an optional GreptimeDB extended data type, carried as
+	// greptime:type, for example "Json". JSON columns are auto-detected from
+	// the written table's schema, so it only needs to be set for columns whose
+	// extended type cannot be inferred from the Arrow type.
+	TypeOverride string
+
+	// semanticType overrides the semantic type declared by the written table's
+	// schema. It is only set through TagColumn, FieldColumn or TimestampColumn;
+	// nil falls back to the table's own schema.
+	semanticType *gpbv1.SemanticType
+}
+
+// TagColumn returns an AutoCreateColumn with the TAG semantic type. Tag
+// columns become the primary key of the created table, in schema order.
+func TagColumn(name string) AutoCreateColumn {
+	return AutoCreateColumn{Name: name, semanticType: ptrOf(gpbv1.SemanticType_TAG)}
+}
+
+// FieldColumn returns an AutoCreateColumn with the FIELD semantic type.
+func FieldColumn(name string) AutoCreateColumn {
+	return AutoCreateColumn{Name: name, semanticType: ptrOf(gpbv1.SemanticType_FIELD)}
+}
+
+// TimestampColumn returns an AutoCreateColumn with the TIMESTAMP semantic
+// type. The timestamp column is the time index of the created table and is
+// written as non-nullable.
+func TimestampColumn(name string) AutoCreateColumn {
+	return AutoCreateColumn{Name: name, semanticType: ptrOf(gpbv1.SemanticType_TIMESTAMP)}
+}
+
+func ptrOf(t gpbv1.SemanticType) *gpbv1.SemanticType {
+	return &t
+}
+
+// AutoCreateSchema carries the column metadata that GreptimeDB Enterprise
+// needs to auto-create a missing table for a Flight bulk insert.
+type AutoCreateSchema struct {
+	Columns []AutoCreateColumn
+}
+
+// WithAutoCreateSchema configures the bulk writer to attach the given column
+// metadata to the Arrow schema of every written record batch, so that
+// GreptimeDB Enterprise can auto-create the table if it does not exist yet.
+func WithAutoCreateSchema(schema *AutoCreateSchema) WriterOption {
+	return func(bw *bulkWriter) {
+		bw.autoCreate = schema
+	}
+}
+
+// applyAutoCreateMetadata returns a copy of rec whose schema carries the
+// auto-create metadata for each column. Metadata is matched to columns by
+// name: an exact match on the written field name wins, falling back to the
+// sanitized name so spec columns work for both sanitized and unsanitized
+// tables. Columns present in the schema override the written table's own
+// column schema, and the table's schema fills in every remaining column.
+// JSON columns are tagged greptime:type=Json so the server can distinguish
+// them from binary columns when creating the table. A schema column that
+// matches nothing in the written table is an error.
+func applyAutoCreateMetadata(
+	rec arrow.Record,
+	columns []*gpbv1.ColumnSchema,
+	schema *AutoCreateSchema,
+) (arrow.Record, error) {
+	if schema == nil || len(schema.Columns) == 0 {
+		return nil, fmt.Errorf("auto-create schema is empty")
+	}
+
+	exactByName := make(map[string]AutoCreateColumn, len(schema.Columns))
+	sanitizedByName := make(map[string]string, len(schema.Columns))
+	for _, col := range schema.Columns {
+		name, err := util.SanitateName(col.Name)
+		if err != nil {
+			return nil, fmt.Errorf("invalid auto-create column name %q: %w", col.Name, err)
+		}
+		if _, dup := exactByName[col.Name]; dup {
+			return nil, fmt.Errorf("duplicate column %q in auto-create schema", col.Name)
+		}
+		if other, dup := sanitizedByName[name]; dup && other != col.Name {
+			return nil, fmt.Errorf(
+				"auto-create schema columns %q and %q are ambiguous after sanitization",
+				other, col.Name,
+			)
+		}
+		exactByName[col.Name] = col
+		sanitizedByName[name] = col.Name
+	}
+
+	lookup := func(fieldName string) (AutoCreateColumn, bool) {
+		if col, ok := exactByName[fieldName]; ok {
+			return col, true
+		}
+		if sanitized, err := util.SanitateName(fieldName); err == nil {
+			if raw, ok := sanitizedByName[sanitized]; ok {
+				return exactByName[raw], true
+			}
+		}
+		return AutoCreateColumn{}, false
+	}
+	consume := func(col AutoCreateColumn) {
+		delete(exactByName, col.Name)
+		if sanitized, err := util.SanitateName(col.Name); err == nil {
+			delete(sanitizedByName, sanitized)
+		}
+	}
+
+	tableByName := make(map[string]*gpbv1.ColumnSchema, len(columns))
+	for _, col := range columns {
+		tableByName[col.ColumnName] = col
+	}
+
+	fields := rec.Schema().Fields()
+	enriched := make([]arrow.Field, len(fields))
+	for i, field := range fields {
+		enriched[i] = field
+		specCol, inSpec := lookup(field.Name)
+		if inSpec {
+			consume(specCol)
+		}
+		tableCol, inTable := tableByName[field.Name]
+
+		semanticType, ok := columnSemanticType(specCol, inSpec, tableCol)
+		if !ok {
+			continue
+		}
+		if semanticType == gpbv1.SemanticType_TIMESTAMP && specCol.TypeOverride != "" {
+			return nil, fmt.Errorf(
+				"column %q is a timestamp and cannot carry a type override",
+				field.Name,
+			)
+		}
+
+		metadata := map[string]string{
+			semanticTypeMetadataKey: semanticTypeString(semanticType),
+		}
+		if specCol.TypeOverride != "" {
+			metadata[typeMetadataKey] = specCol.TypeOverride
+		} else if inTable && tableCol.Datatype == gpbv1.ColumnDataType_JSON {
+			metadata[typeMetadataKey] = "Json"
+		}
+		if specCol.Comment != "" {
+			metadata[commentMetadataKey] = specCol.Comment
+		}
+
+		nullable := field.Nullable
+		if semanticType == gpbv1.SemanticType_TIMESTAMP {
+			nullable = false
+		}
+		enriched[i] = arrow.Field{
+			Name:     field.Name,
+			Type:     field.Type,
+			Nullable: nullable,
+			Metadata: arrow.MetadataFrom(metadata),
+		}
+	}
+
+	if len(exactByName) > 0 {
+		return nil, fmt.Errorf(
+			"auto-create schema columns %v not found in the written table",
+			slices.Sorted(maps.Keys(exactByName)),
+		)
+	}
+
+	metadata := rec.Schema().Metadata()
+	return array.NewRecord(arrow.NewSchema(enriched, &metadata), rec.Columns(), rec.NumRows()), nil
+}
+
+func columnSemanticType(
+	specCol AutoCreateColumn,
+	inSpec bool,
+	tableCol *gpbv1.ColumnSchema,
+) (gpbv1.SemanticType, bool) {
+	if inSpec && specCol.semanticType != nil {
+		return *specCol.semanticType, true
+	}
+	if tableCol != nil {
+		return tableCol.SemanticType, true
+	}
+	return gpbv1.SemanticType_TAG, false
+}
+
+func semanticTypeString(t gpbv1.SemanticType) string {
+	switch t {
+	case gpbv1.SemanticType_TAG:
+		return "tag"
+	case gpbv1.SemanticType_FIELD:
+		return "field"
+	case gpbv1.SemanticType_TIMESTAMP:
+		return "timestamp"
+	default:
+		return ""
+	}
+}

--- a/bulk/autocreate_test.go
+++ b/bulk/autocreate_test.go
@@ -1,0 +1,232 @@
+/*
+ * Copyright 2026 Greptime Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package bulk
+
+import (
+	"testing"
+	"time"
+
+	gpbv1 "github.com/GreptimeTeam/greptime-proto/go/greptime/v1"
+	"github.com/apache/arrow/go/v17/arrow"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/GreptimeTeam/greptimedb-ingester-go/table"
+	"github.com/GreptimeTeam/greptimedb-ingester-go/table/types"
+)
+
+func TestAutoCreateColumnConstructors(t *testing.T) {
+	tag := TagColumn("host")
+	require.NotNil(t, tag.semanticType)
+	assert.Equal(t, gpbv1.SemanticType_TAG, *tag.semanticType)
+
+	field := FieldColumn("temperature")
+	require.NotNil(t, field.semanticType)
+	assert.Equal(t, gpbv1.SemanticType_FIELD, *field.semanticType)
+
+	ts := TimestampColumn("ts")
+	require.NotNil(t, ts.semanticType)
+	assert.Equal(t, gpbv1.SemanticType_TIMESTAMP, *ts.semanticType)
+
+	plain := AutoCreateColumn{Name: "host", Comment: "a comment"}
+	assert.Nil(t, plain.semanticType, "a plain struct literal must not override the semantic type")
+}
+
+func TestWithAutoCreateSchemaOption(t *testing.T) {
+	bw := &bulkWriter{}
+	WithAutoCreateSchema(&AutoCreateSchema{Columns: []AutoCreateColumn{TagColumn("host")}})(bw)
+	require.NotNil(t, bw.autoCreate)
+	require.Len(t, bw.autoCreate.Columns, 1)
+}
+
+func TestApplyAutoCreateMetadata(t *testing.T) {
+	rows := testRows(t, true)
+	record, err := types.NewArrowConverter().ToArrow(rows)
+	require.NoError(t, err)
+	defer record.Release()
+
+	schema := &AutoCreateSchema{
+		Columns: []AutoCreateColumn{
+			TagColumn("host"),
+			{Name: "temperature", Comment: "sensor temperature"},
+			TimestampColumn("ts"),
+			FieldColumn("payload"),
+		},
+	}
+	enriched, err := applyAutoCreateMetadata(record, rows.Schema, schema)
+	require.NoError(t, err)
+	defer enriched.Release()
+
+	require.Equal(t, record.NumRows(), enriched.NumRows())
+	require.Equal(t, record.NumCols(), enriched.NumCols())
+
+	field := enriched.Schema().Field(0)
+	assert.Equal(t, "host", field.Name)
+	assert.True(t, field.Nullable)
+	assertMetadata(t, field, semanticTypeMetadataKey, "tag")
+
+	field = enriched.Schema().Field(1)
+	assert.Equal(t, "temperature", field.Name)
+	assert.True(t, field.Nullable)
+	assertMetadata(t, field, semanticTypeMetadataKey, "field")
+	assertMetadata(t, field, commentMetadataKey, "sensor temperature")
+
+	field = enriched.Schema().Field(2)
+	assert.Equal(t, "ts", field.Name)
+	assert.False(t, field.Nullable, "the timestamp column must be non-nullable")
+	assertMetadata(t, field, semanticTypeMetadataKey, "timestamp")
+
+	field = enriched.Schema().Field(3)
+	assert.Equal(t, "payload", field.Name)
+	assert.True(t, field.Nullable)
+	assertMetadata(t, field, semanticTypeMetadataKey, "field")
+	assertMetadata(t, field, typeMetadataKey, "Json")
+}
+
+func TestApplyAutoCreateMetadataFallsBackToTableSchema(t *testing.T) {
+	rows := testRows(t, false)
+	record, err := types.NewArrowConverter().ToArrow(rows)
+	require.NoError(t, err)
+	defer record.Release()
+
+	// Only a comment is provided for one column; semantic types come from the
+	// table's own schema, including the JSON type override.
+	schema := &AutoCreateSchema{
+		Columns: []AutoCreateColumn{{Name: "temperature", Comment: "sensor temperature"}},
+	}
+	enriched, err := applyAutoCreateMetadata(record, rows.Schema, schema)
+	require.NoError(t, err)
+	defer enriched.Release()
+
+	assertMetadata(t, enriched.Schema().Field(0), semanticTypeMetadataKey, "tag")
+	assertMetadata(t, enriched.Schema().Field(1), semanticTypeMetadataKey, "field")
+	assertMetadata(t, enriched.Schema().Field(1), commentMetadataKey, "sensor temperature")
+	assertMetadata(t, enriched.Schema().Field(2), semanticTypeMetadataKey, "timestamp")
+	assert.False(t, enriched.Schema().Field(2).Nullable)
+}
+
+func TestApplyAutoCreateMetadataRejectsInvalidSchemas(t *testing.T) {
+	rows := testRows(t, false)
+	record, err := types.NewArrowConverter().ToArrow(rows)
+	require.NoError(t, err)
+	defer record.Release()
+
+	t.Run("empty schema", func(t *testing.T) {
+		_, err := applyAutoCreateMetadata(record, rows.Schema, &AutoCreateSchema{})
+		require.Error(t, err)
+	})
+
+	t.Run("duplicate column", func(t *testing.T) {
+		_, err := applyAutoCreateMetadata(record, rows.Schema, &AutoCreateSchema{
+			Columns: []AutoCreateColumn{TagColumn("host"), TagColumn("host")},
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("type override on timestamp", func(t *testing.T) {
+		_, err := applyAutoCreateMetadata(record, rows.Schema, &AutoCreateSchema{
+			Columns: []AutoCreateColumn{{Name: "ts", TypeOverride: "Json"}},
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("spec column not in table", func(t *testing.T) {
+		_, err := applyAutoCreateMetadata(record, rows.Schema, &AutoCreateSchema{
+			Columns: []AutoCreateColumn{TagColumn("hotst")},
+		})
+		require.ErrorContains(t, err, `[hotst]`)
+	})
+
+	t.Run("ambiguous after sanitization", func(t *testing.T) {
+		_, err := applyAutoCreateMetadata(record, rows.Schema, &AutoCreateSchema{
+			Columns: []AutoCreateColumn{TagColumn("MyHost"), TagColumn("my_host")},
+		})
+		require.ErrorContains(t, err, "ambiguous")
+	})
+}
+
+// A spec column that differs from the written field only by sanitization still
+// matches, so both sanitized and unsanitized tables are supported.
+func TestApplyAutoCreateMetadataMatchesBySanitizedName(t *testing.T) {
+	rows := testRows(t, false)
+	record, err := types.NewArrowConverter().ToArrow(rows)
+	require.NoError(t, err)
+	defer record.Release()
+
+	schema := &AutoCreateSchema{
+		Columns: []AutoCreateColumn{{Name: "HOST", Comment: "source host"}},
+	}
+	enriched, err := applyAutoCreateMetadata(record, rows.Schema, schema)
+	require.NoError(t, err)
+	defer enriched.Release()
+
+	assertMetadata(t, enriched.Schema().Field(0), commentMetadataKey, "source host")
+}
+
+// With a table built via WithSanitate(false), spec columns match by exact
+// name, so their overrides are not silently dropped.
+func TestApplyAutoCreateMetadataMatchesUnsanitizedTable(t *testing.T) {
+	tb, err := table.New("test_table")
+	require.NoError(t, err)
+	tb.WithSanitate(false)
+	require.NoError(t, tb.AddFieldColumn("MyHost", types.STRING))
+	require.NoError(t, tb.AddTimestampColumn("Ts", types.TIMESTAMP_MICROSECOND))
+	require.NoError(t, tb.AddRow("host-1", time.Unix(0, 0).UnixMicro()))
+	rows := tb.GetRows()
+
+	record, err := types.NewArrowConverter().ToArrow(rows)
+	require.NoError(t, err)
+	defer record.Release()
+
+	schema := &AutoCreateSchema{
+		Columns: []AutoCreateColumn{TagColumn("MyHost")},
+	}
+	enriched, err := applyAutoCreateMetadata(record, rows.Schema, schema)
+	require.NoError(t, err)
+	defer enriched.Release()
+
+	// The semantic type override must win over the table's FIELD declaration.
+	assertMetadata(t, enriched.Schema().Field(0), semanticTypeMetadataKey, "tag")
+}
+
+func testRows(t *testing.T, withJSON bool) *gpbv1.Rows {
+	t.Helper()
+	tb, err := table.New("test_table")
+	require.NoError(t, err)
+	require.NoError(t, tb.AddTagColumn("host", types.STRING))
+	require.NoError(t, tb.AddFieldColumn("temperature", types.FLOAT64))
+	require.NoError(t, tb.AddTimestampColumn("ts", types.TIMESTAMP_MICROSECOND))
+	if withJSON {
+		require.NoError(t, tb.AddFieldColumn("payload", types.JSON))
+	}
+
+	now := time.Unix(0, 0).UnixMicro()
+	if withJSON {
+		require.NoError(t, tb.AddRow("host-1", 20.5, now, `{"a":1}`))
+		require.NoError(t, tb.AddRow("host-1", 20.5, now, `{"b":2}`))
+	} else {
+		require.NoError(t, tb.AddRow("host-1", 20.5, now))
+	}
+	return tb.GetRows()
+}
+
+func assertMetadata(t *testing.T, field arrow.Field, key, want string) {
+	t.Helper()
+	got, ok := field.Metadata.GetValue(key)
+	require.True(t, ok, "field %q must carry metadata %q", field.Name, key)
+	assert.Equal(t, want, got)
+}

--- a/bulk/autocreate_test.go
+++ b/bulk/autocreate_test.go
@@ -17,17 +17,70 @@
 package bulk
 
 import (
+	"context"
+	"errors"
 	"testing"
 	"time"
 
 	gpbv1 "github.com/GreptimeTeam/greptime-proto/go/greptime/v1"
 	"github.com/apache/arrow/go/v17/arrow"
+	"github.com/apache/arrow/go/v17/arrow/flight"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 
 	"github.com/GreptimeTeam/greptimedb-ingester-go/table"
 	"github.com/GreptimeTeam/greptimedb-ingester-go/table/types"
 )
+
+var errStopBeforeStreamCreation = errors.New("stop before stream creation")
+
+type contextCapturingFlightClient struct {
+	flight.FlightServiceClient
+	ctx context.Context
+}
+
+func (c *contextCapturingFlightClient) DoPut(
+	ctx context.Context,
+	_ ...grpc.CallOption,
+) (flight.FlightService_DoPutClient, error) {
+	c.ctx = ctx
+	return nil, errStopBeforeStreamCreation
+}
+
+func TestWithAutoCreateSchemaAddsFlightHintBeforeDoPut(t *testing.T) {
+	flightClient := &contextCapturingFlightClient{}
+	client := &BulkClient{client: flightClient}
+
+	_, err := client.NewBulkWriter(context.Background(), WithAutoCreateSchema(&AutoCreateSchema{
+		Columns: []AutoCreateColumn{TimestampColumn("ts")},
+	}))
+	require.ErrorIs(t, err, errStopBeforeStreamCreation)
+
+	md, ok := metadata.FromOutgoingContext(flightClient.ctx)
+	require.True(t, ok)
+	assert.Equal(t, []string{"true"}, md.Get("x-greptime-hint-auto_create_table"))
+}
+
+func TestWithAutoCreateSchemaPreservesAndUpdatesCombinedHints(t *testing.T) {
+	flightClient := &contextCapturingFlightClient{}
+	client := &BulkClient{client: flightClient}
+	ctx := metadata.NewOutgoingContext(context.Background(), metadata.Pairs(
+		"authorization", "secret",
+		"x-greptime-hints", "ttl=7d,auto_create_table=false",
+	))
+
+	_, err := client.NewBulkWriter(ctx, WithAutoCreateSchema(&AutoCreateSchema{
+		Columns: []AutoCreateColumn{TimestampColumn("ts")},
+	}))
+	require.ErrorIs(t, err, errStopBeforeStreamCreation)
+
+	md, ok := metadata.FromOutgoingContext(flightClient.ctx)
+	require.True(t, ok)
+	assert.Equal(t, []string{"secret"}, md.Get("authorization"))
+	assert.Equal(t, []string{"ttl=7d,auto_create_table=true"}, md.Get("x-greptime-hints"))
+}
 
 func TestAutoCreateColumnConstructors(t *testing.T) {
 	tag := TagColumn("host")
@@ -157,6 +210,134 @@ func TestApplyAutoCreateMetadataRejectsInvalidSchemas(t *testing.T) {
 		})
 		require.ErrorContains(t, err, "ambiguous")
 	})
+}
+
+func TestApplyAutoCreateMetadataRequiresExactlyOneTimestamp(t *testing.T) {
+	t.Run("missing timestamp", func(t *testing.T) {
+		rows := &gpbv1.Rows{
+			Schema: []*gpbv1.ColumnSchema{{
+				ColumnName:   "value",
+				SemanticType: gpbv1.SemanticType_FIELD,
+				Datatype:     gpbv1.ColumnDataType_STRING,
+			}},
+			Rows: []*gpbv1.Row{{Values: []*gpbv1.Value{{
+				ValueData: &gpbv1.Value_StringValue{StringValue: "v"},
+			}}}},
+		}
+		record, err := types.NewArrowConverter().ToArrow(rows)
+		require.NoError(t, err)
+		defer record.Release()
+
+		_, err = applyAutoCreateMetadata(record, rows.Schema, &AutoCreateSchema{
+			Columns: []AutoCreateColumn{FieldColumn("value")},
+		})
+		require.ErrorContains(t, err, "exactly one timestamp")
+	})
+
+	t.Run("multiple timestamps", func(t *testing.T) {
+		rows := &gpbv1.Rows{
+			Schema: []*gpbv1.ColumnSchema{
+				{ColumnName: "ts1", SemanticType: gpbv1.SemanticType_TIMESTAMP, Datatype: gpbv1.ColumnDataType_TIMESTAMP_MILLISECOND},
+				{ColumnName: "ts2", SemanticType: gpbv1.SemanticType_TIMESTAMP, Datatype: gpbv1.ColumnDataType_TIMESTAMP_MILLISECOND},
+			},
+			Rows: []*gpbv1.Row{{Values: []*gpbv1.Value{
+				{ValueData: &gpbv1.Value_TimestampMillisecondValue{TimestampMillisecondValue: 1}},
+				{ValueData: &gpbv1.Value_TimestampMillisecondValue{TimestampMillisecondValue: 2}},
+			}}},
+		}
+		record, err := types.NewArrowConverter().ToArrow(rows)
+		require.NoError(t, err)
+		defer record.Release()
+
+		_, err = applyAutoCreateMetadata(record, rows.Schema, &AutoCreateSchema{
+			Columns: []AutoCreateColumn{TimestampColumn("ts1"), TimestampColumn("ts2")},
+		})
+		require.ErrorContains(t, err, "exactly one timestamp")
+	})
+}
+
+func TestApplyAutoCreateMetadataRejectsNonTimestampTimeIndex(t *testing.T) {
+	rows := &gpbv1.Rows{
+		Schema: []*gpbv1.ColumnSchema{{
+			ColumnName:   "ts",
+			SemanticType: gpbv1.SemanticType_TIMESTAMP,
+			Datatype:     gpbv1.ColumnDataType_STRING,
+		}},
+		Rows: []*gpbv1.Row{{Values: []*gpbv1.Value{{
+			ValueData: &gpbv1.Value_StringValue{StringValue: "not-a-timestamp"},
+		}}}},
+	}
+	record, err := types.NewArrowConverter().ToArrow(rows)
+	require.NoError(t, err)
+	defer record.Release()
+
+	_, err = applyAutoCreateMetadata(record, rows.Schema, &AutoCreateSchema{
+		Columns: []AutoCreateColumn{TimestampColumn("ts")},
+	})
+	require.ErrorContains(t, err, "must have Arrow timestamp type without timezone")
+}
+
+func TestApplyAutoCreateMetadataRejectsUnsupportedExtendedTypes(t *testing.T) {
+	rows := testRows(t, false)
+	record, err := types.NewArrowConverter().ToArrow(rows)
+	require.NoError(t, err)
+	defer record.Release()
+
+	t.Run("vector", func(t *testing.T) {
+		_, err := applyAutoCreateMetadata(record, rows.Schema, &AutoCreateSchema{
+			Columns: []AutoCreateColumn{{Name: "temperature", TypeOverride: "Vector(3)"}},
+		})
+		require.ErrorContains(t, err, "only Json is supported")
+	})
+
+	t.Run("json on non-binary Arrow field", func(t *testing.T) {
+		_, err := applyAutoCreateMetadata(record, rows.Schema, &AutoCreateSchema{
+			Columns: []AutoCreateColumn{{Name: "temperature", TypeOverride: "Json"}},
+		})
+		require.ErrorContains(t, err, "requires Arrow Binary type")
+	})
+}
+
+func TestApplyAutoCreateMetadataRejectsInvalidSemanticType(t *testing.T) {
+	rows := &gpbv1.Rows{
+		Schema: []*gpbv1.ColumnSchema{
+			{ColumnName: "ts", SemanticType: gpbv1.SemanticType_TIMESTAMP, Datatype: gpbv1.ColumnDataType_TIMESTAMP_MILLISECOND},
+			{ColumnName: "value", SemanticType: gpbv1.SemanticType(99), Datatype: gpbv1.ColumnDataType_STRING},
+		},
+		Rows: []*gpbv1.Row{{Values: []*gpbv1.Value{
+			{ValueData: &gpbv1.Value_TimestampMillisecondValue{TimestampMillisecondValue: 1}},
+			{ValueData: &gpbv1.Value_StringValue{StringValue: "v"}},
+		}}},
+	}
+	record, err := types.NewArrowConverter().ToArrow(rows)
+	require.NoError(t, err)
+	defer record.Release()
+
+	_, err = applyAutoCreateMetadata(record, rows.Schema, &AutoCreateSchema{
+		Columns: []AutoCreateColumn{TimestampColumn("ts")},
+	})
+	require.ErrorContains(t, err, "unsupported semantic type")
+}
+
+func TestApplyAutoCreateMetadataRejectsDuplicateWrittenColumns(t *testing.T) {
+	rows := &gpbv1.Rows{
+		Schema: []*gpbv1.ColumnSchema{
+			{ColumnName: "ts", SemanticType: gpbv1.SemanticType_TIMESTAMP, Datatype: gpbv1.ColumnDataType_TIMESTAMP_MILLISECOND},
+			{ColumnName: "ts", SemanticType: gpbv1.SemanticType_FIELD, Datatype: gpbv1.ColumnDataType_TIMESTAMP_MILLISECOND},
+		},
+		Rows: []*gpbv1.Row{{Values: []*gpbv1.Value{
+			{ValueData: &gpbv1.Value_TimestampMillisecondValue{TimestampMillisecondValue: 1}},
+			{ValueData: &gpbv1.Value_TimestampMillisecondValue{TimestampMillisecondValue: 2}},
+		}}},
+	}
+	record, err := types.NewArrowConverter().ToArrow(rows)
+	require.NoError(t, err)
+	defer record.Release()
+
+	_, err = applyAutoCreateMetadata(record, rows.Schema, &AutoCreateSchema{
+		Columns: []AutoCreateColumn{TimestampColumn("ts")},
+	})
+	require.ErrorContains(t, err, "duplicate written column")
 }
 
 // A spec column that differs from the written field only by sanitization still

--- a/bulk/bulk.go
+++ b/bulk/bulk.go
@@ -76,19 +76,22 @@ type bulkWriter struct {
 // NewBulkWriter creates a new BulkWriter instance for streaming data to GreptimeDB.
 // Callers must call Close when done to release resources and stop the background goroutine.
 func (c *BulkClient) NewBulkWriter(ctx context.Context, opts ...WriterOption) (BulkWriter, error) {
-	stream, err := c.client.DoPut(ctx)
-	if err != nil {
-		return nil, err
-	}
-
 	bw := &bulkWriter{
 		client:   c,
-		stream:   stream,
 		recvDone: make(chan struct{}),
 	}
 	for _, opt := range opts {
 		opt(bw)
 	}
+	if bw.autoCreate != nil {
+		ctx = withAutoCreateTableHint(ctx)
+	}
+
+	stream, err := c.client.DoPut(ctx)
+	if err != nil {
+		return nil, err
+	}
+	bw.stream = stream
 	go bw.recvLoop()
 	return bw, nil
 }

--- a/bulk/bulk.go
+++ b/bulk/bulk.go
@@ -57,10 +57,15 @@ type BulkWriter interface {
 	Close() (uint32, error)
 }
 
+// WriterOption configures a BulkWriter.
+type WriterOption func(*bulkWriter)
+
 type bulkWriter struct {
 	client *BulkClient
 	stream flight.FlightService_DoPutClient
 	writer *flight.Writer
+
+	autoCreate *AutoCreateSchema // attaches auto-create metadata to written schemas
 
 	recvDone chan struct{} // closed when the recv goroutine exits
 	mu       sync.RWMutex
@@ -70,7 +75,7 @@ type bulkWriter struct {
 
 // NewBulkWriter creates a new BulkWriter instance for streaming data to GreptimeDB.
 // Callers must call Close when done to release resources and stop the background goroutine.
-func (c *BulkClient) NewBulkWriter(ctx context.Context) (BulkWriter, error) {
+func (c *BulkClient) NewBulkWriter(ctx context.Context, opts ...WriterOption) (BulkWriter, error) {
 	stream, err := c.client.DoPut(ctx)
 	if err != nil {
 		return nil, err
@@ -80,6 +85,9 @@ func (c *BulkClient) NewBulkWriter(ctx context.Context) (BulkWriter, error) {
 		client:   c,
 		stream:   stream,
 		recvDone: make(chan struct{}),
+	}
+	for _, opt := range opts {
+		opt(bw)
 	}
 	go bw.recvLoop()
 	return bw, nil
@@ -131,9 +139,19 @@ func (bw *bulkWriter) Write(tb *table.Table) error {
 		return err
 	}
 
-	record, err := converter.ToArrow(tb.GetRows())
+	rows := tb.GetRows()
+	record, err := converter.ToArrow(rows)
 	if err != nil {
 		return fmt.Errorf("failed to convert to Arrow: %w", err)
+	}
+	if bw.autoCreate != nil {
+		enriched, err := applyAutoCreateMetadata(record, rows.Schema, bw.autoCreate)
+		if err != nil {
+			record.Release()
+			return fmt.Errorf("failed to apply auto-create schema metadata: %w", err)
+		}
+		record.Release()
+		record = enriched
 	}
 	defer record.Release()
 
@@ -176,7 +194,17 @@ func (bw *bulkWriter) Close() (uint32, error) {
 
 // BulkWrite performs a single bulk write operation with the given table data.
 func (c *BulkClient) BulkWrite(ctx context.Context, tb *table.Table) (*gpbv1.GreptimeResponse, error) {
-	bw, err := c.NewBulkWriter(ctx)
+	return c.BulkWriteWithOptions(ctx, tb)
+}
+
+// BulkWriteWithOptions performs a single bulk write operation with the given
+// table data, applying the provided writer options (e.g. WithAutoCreateSchema).
+func (c *BulkClient) BulkWriteWithOptions(
+	ctx context.Context,
+	tb *table.Table,
+	opts ...WriterOption,
+) (*gpbv1.GreptimeResponse, error) {
+	bw, err := c.NewBulkWriter(ctx, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/client.go
+++ b/client.go
@@ -27,6 +27,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 
+	"github.com/GreptimeTeam/greptimedb-ingester-go/bulk"
 	"github.com/GreptimeTeam/greptimedb-ingester-go/internal/pool"
 	"github.com/GreptimeTeam/greptimedb-ingester-go/loadbalancer"
 	"github.com/GreptimeTeam/greptimedb-ingester-go/request"
@@ -424,8 +425,20 @@ func (c *Client) Close() error {
 // duplicate rows. On failure, rebuild by calling BulkWrite again — a
 // health-aware selector then steers away from the endpoint that just failed.
 func (c *Client) BulkWrite(ctx context.Context, table *table.Table) (*gpb.GreptimeResponse, error) {
+	return c.BulkWriteWithOptions(ctx, table)
+}
+
+// BulkWriteWithOptions performs a bulk write with the given writer options.
+// It behaves like BulkWrite, and additionally applies the provided writer
+// options (e.g. bulk.WithAutoCreateSchema) when creating the underlying bulk
+// writer.
+func (c *Client) BulkWriteWithOptions(
+	ctx context.Context,
+	table *table.Table,
+	opts ...bulk.WriterOption,
+) (*gpb.GreptimeResponse, error) {
 	peer := c.selector.Select(c.pool.Addrs(), nil)
-	resp, err := c.pool.Get(peer).Bulk.BulkWrite(ctx, table)
+	resp, err := c.pool.Get(peer).Bulk.BulkWriteWithOptions(ctx, table, opts...)
 	reportOutcome(c.health, peer, err)
 	return resp, err
 }

--- a/examples/bulkwrite/README.md
+++ b/examples/bulkwrite/README.md
@@ -13,6 +13,32 @@ CREATE TABLE bulk_insert_table (
 );
 ```
 
+## Auto-create table (GreptimeDB Enterprise)
+
+When the target table does not exist yet, GreptimeDB Enterprise can auto-create
+it from the column metadata attached to the Arrow schema of the bulk write. Pass
+`bulk.WithAutoCreateSchema` when creating the bulk writer to enable it:
+
+```go
+response, err := c.client.BulkWriteWithOptions(ctx, data,
+	bulk.WithAutoCreateSchema(&bulk.AutoCreateSchema{
+		Columns: []bulk.AutoCreateColumn{
+			bulk.TagColumn("id"),
+			{Name: "host", Comment: "source host"},
+			bulk.FieldColumn("temperature"),
+			bulk.TimestampColumn("ts"),
+		},
+	}),
+)
+```
+
+Every column of the table is described by its semantic type: `tag` columns form
+the primary key (in order), exactly one `timestamp` column becomes the time
+index (written non-nullable), and the rest are `field` columns. Semantic types
+default to the ones declared by the table's schema, so only the columns you want
+to override or annotate need to appear in the list. JSON columns are flagged
+automatically with `greptime:type=Json`.
+
 ## Insert
 
 ```go

--- a/examples/bulkwrite/README.md
+++ b/examples/bulkwrite/README.md
@@ -17,7 +17,8 @@ CREATE TABLE bulk_insert_table (
 
 When the target table does not exist yet, GreptimeDB Enterprise can auto-create
 it from the column metadata attached to the Arrow schema of the bulk write. Pass
-`bulk.WithAutoCreateSchema` when creating the bulk writer to enable it:
+`bulk.WithAutoCreateSchema` when creating the bulk writer to attach the schema
+and send the `auto_create_table=true` Flight request hint:
 
 ```go
 response, err := c.client.BulkWriteWithOptions(ctx, data,
@@ -37,7 +38,10 @@ the primary key (in order), exactly one `timestamp` column becomes the time
 index (written non-nullable), and the rest are `field` columns. Semantic types
 default to the ones declared by the table's schema, so only the columns you want
 to override or annotate need to appear in the list. JSON columns are flagged
-automatically with `greptime:type=Json`.
+automatically with `greptime:type=Json` and encoded as Arrow Binary. Other
+extended types (including Vector) are rejected because the server does not
+support them for Flight bulk auto-create. The server must also enable the
+feature globally; the request hint cannot override a disabled server setting.
 
 ## Insert
 

--- a/examples/bulkwrite/main.go
+++ b/examples/bulkwrite/main.go
@@ -100,7 +100,7 @@ func main() {
 
 	// When the target table does not exist yet, GreptimeDB Enterprise can
 	// auto-create it from the schema metadata attached to the Arrow schema.
-	// Pass the required column metadata when creating the bulk writer.
+	// The option also sends auto_create_table=true before opening the stream.
 	response, err := c.client.BulkWriteWithOptions(context.TODO(), data,
 		bulk.WithAutoCreateSchema(&bulk.AutoCreateSchema{
 			Columns: []bulk.AutoCreateColumn{

--- a/examples/bulkwrite/main.go
+++ b/examples/bulkwrite/main.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	greptime "github.com/GreptimeTeam/greptimedb-ingester-go"
+	"github.com/GreptimeTeam/greptimedb-ingester-go/bulk"
 	"github.com/GreptimeTeam/greptimedb-ingester-go/table"
 	"github.com/GreptimeTeam/greptimedb-ingester-go/table/types"
 )
@@ -97,7 +98,19 @@ func main() {
 	data := initData()
 	log.Printf("Writing %d rows to table", len(data.GetRows().Rows))
 
-	response, err := c.client.BulkWrite(context.TODO(), data)
+	// When the target table does not exist yet, GreptimeDB Enterprise can
+	// auto-create it from the schema metadata attached to the Arrow schema.
+	// Pass the required column metadata when creating the bulk writer.
+	response, err := c.client.BulkWriteWithOptions(context.TODO(), data,
+		bulk.WithAutoCreateSchema(&bulk.AutoCreateSchema{
+			Columns: []bulk.AutoCreateColumn{
+				bulk.TagColumn("id"),
+				{Name: "host", Comment: "source host"},
+				bulk.FieldColumn("temperature"),
+				bulk.TimestampColumn("ts"),
+			},
+		}),
+	)
 	if err != nil {
 		log.Fatalf("BulkWrite failed after retries: %v", err)
 	}

--- a/table/types/arrow.go
+++ b/table/types/arrow.go
@@ -139,7 +139,10 @@ func (c *ArrowConverter) convertToArrowType(dt gpbv1.ColumnDataType) (arrow.Data
 		return arrow.FixedWidthTypes.Boolean, nil
 	case gpbv1.ColumnDataType_STRING:
 		return arrow.BinaryTypes.String, nil
-	case gpbv1.ColumnDataType_BINARY:
+	case gpbv1.ColumnDataType_BINARY, gpbv1.ColumnDataType_JSON:
+		// JSON is serialized as its UTF-8 bytes and flagged with the
+		// greptime:type=Json metadata by the bulk writer's auto-create path so
+		// the server can tell it apart from a plain binary column.
 		return arrow.BinaryTypes.Binary, nil
 	case gpbv1.ColumnDataType_TIMESTAMP_MILLISECOND:
 		return timestampTypeMs, nil
@@ -261,6 +264,10 @@ func (c *ArrowConverter) fillValue(builder array.Builder, value *gpbv1.Value, da
 	case *array.BinaryBuilder:
 		if value == nil {
 			b.AppendNull()
+		} else if s, ok := value.ValueData.(*gpbv1.Value_StringValue); ok {
+			// JSON values are transported as strings (see BuildJSON); store
+			// their UTF-8 bytes in the binary column.
+			b.Append([]byte(s.StringValue))
 		} else {
 			b.Append(value.GetBinaryValue())
 		}

--- a/table/types/arrow_test.go
+++ b/table/types/arrow_test.go
@@ -44,6 +44,40 @@ func TestConvertToArrowType_DatetimeIsMicrosecond(t *testing.T) {
 	assert.Equal(t, dtType, tsType, "DATETIME must map to the same Arrow type as TIMESTAMP_MICROSECOND")
 }
 
+// JSON columns are serialized as their UTF-8 bytes into an Arrow binary array,
+// mirroring how the server stores JSON and how the bulk auto-create path flags
+// them with greptime:type=Json.
+func TestToArrow_JsonColumn(t *testing.T) {
+	rows := &gpbv1.Rows{
+		Schema: []*gpbv1.ColumnSchema{
+			{
+				ColumnName:   "payload",
+				SemanticType: gpbv1.SemanticType_FIELD,
+				Datatype:     gpbv1.ColumnDataType_JSON,
+			},
+		},
+		Rows: []*gpbv1.Row{
+			{
+				Values: []*gpbv1.Value{
+					{ValueData: &gpbv1.Value_StringValue{StringValue: `{"a":1}`}},
+				},
+			},
+		},
+	}
+
+	record, err := NewArrowConverter().ToArrow(rows)
+	require.NoError(t, err)
+	defer record.Release()
+
+	require.Equal(t, int64(1), record.NumRows())
+	require.Equal(t, int64(1), record.NumCols())
+	assert.Equal(t, arrow.BinaryTypes.Binary, record.Schema().Field(0).Type)
+
+	col, ok := record.Column(0).(*array.Binary)
+	require.True(t, ok, "column must be *array.Binary")
+	assert.Equal(t, []byte(`{"a":1}`), col.Value(0))
+}
+
 func TestToArrow_DatetimeColumn(t *testing.T) {
 	now := time.Date(2026, 4, 21, 10, 30, 45, 123456000, time.UTC)
 	micros := now.UnixMicro()


### PR DESCRIPTION
## What's this PR for?

GreptimeDB Enterprise added auto-create table support for Flight bulk inserts (GreptimeTeam/greptimedb-enterprise#845): when the target table does not exist, the server builds a `CreateTableExpr` from the Arrow schema's field metadata. This PR adds the client-side support for specifying that metadata when creating a bulk writer.

## Changes

- **`bulk`**: new `WithAutoCreateSchema` writer option (`NewBulkWriter(ctx, opts...)`). Each `AutoCreateColumn` is matched to a written column by name (exact match first, then sanitized name, so both sanitized and unsanitized tables work) and attached to the Arrow schema as field metadata:
  - `greptime:semantic_type` = `tag` / `field` / `timestamp` (overridable via `TagColumn`/`FieldColumn`/`TimestampColumn`; defaults to the written table's own schema)
  - `greptime:comment` (optional)
  - `greptime:type` (optional; JSON columns are flagged `Json` automatically)
  - the timestamp column is written non-nullable, as required by the server
  - unmatched or ambiguous spec columns fail fast
- **`client.go`**: new `Client.BulkWriteWithOptions` (same endpoint selection/health reporting as `BulkWrite`)
- **`table/types`**: JSON column support in the bulk Arrow converter (mapped to Arrow Binary with UTF-8 bytes, mirroring the Java SDK and the server contract)
- unit tests for metadata attachment, fallback, and invalid schemas; `examples/bulkwrite` and README updated

## Usage

```go
resp, err := client.BulkWriteWithOptions(ctx, tbl,
    bulk.WithAutoCreateSchema(&bulk.AutoCreateSchema{
        Columns: []bulk.AutoCreateColumn{
            bulk.TagColumn("id"),
            {Name: "host", Comment: "source host"},
            bulk.FieldColumn("temperature"),
            bulk.TimestampColumn("ts"),
        },
    }),
)
```

## Verification

- `go build ./...`, `go vet ./...`
- `go test ./...` (89 passed)
- `golangci-lint run ./...` (0 issues)